### PR TITLE
make install fixes

### DIFF
--- a/tools/build/Makefile.in
+++ b/tools/build/Makefile.in
@@ -41,7 +41,6 @@ CINCLUDES        = -I$(PARROT_INCLUDE_DIR) -I$(PARROT_INCLUDE_DIR)/pmc
 LINKARGS         = $(LDFLAGS) $(LD_LOAD_FLAGS) $(LIBPARROT) @libs@ @icu_shared@
 
 # nqp directories
-NQP_LANG_DIR     = $(PARROT_LIB_DIR)/languages/nqp
 DYNEXT_DIR       = dynext
 PMC_DIR          = src/pmc
 OPS_DIR          = src/ops
@@ -220,7 +219,6 @@ CLEANUPS = \
 all: $(NQP_EXE)
 
 install: all
-	$(MKPATH)               $(DESTDIR)$(NQP_LANG_DIR)
 	$(MKPATH)               $(DESTDIR)$(PARROT_LIBRARY_DIR)
 	$(CP)  $(P6REGEX_PBC)  $(DESTDIR)$(PARROT_LIBRARY_DIR)/$(P6REGEX_PBC)
 	$(CP)  $(REGEX_PBC)    $(DESTDIR)$(PARROT_LIBRARY_DIR)/$(REGEX_PBC)


### PR DESCRIPTION
The first commit fixes the fact that `make install` doesn't create PARROT_LIBRARY_DIR.  This is a problem when someone (like me) uses DESTDIR to allow for clean install/removal.  (Yay stow!)

The second one removes NQP_LANGUAGE_DIR which doesn't seem to be used anywhere.  Feel free to drop this one if it serves some purpose I can't see.
