### PR TITLE
Catch exceptions in VTABLE find_method

### DIFF
--- a/src/pmc/sixmodelobject.pmc
+++ b/src/pmc/sixmodelobject.pmc
@@ -99,12 +99,22 @@ pmclass SixModelObject manual_attrs dynpmc group nqp {
         PMC *m = PMCNULL;
         PMC *decont;
         Parrot_runloop jmp;
+        Parrot_Context *initialctx;
+        int runloop_id;
 
+        initialctx = CONTEXT(interp);
+        runloop_id = interp->current_runloop_id;
         if (!setjmp(jmp.resume)) {
             Parrot_ex_add_c_handler(interp, &jmp);
             /* try */
             decont = decontainerize(interp, SELF);
             m = STABLE(decont)->find_method(interp, decont, name, NO_HINT);
+        } else {
+            while (interp->current_runloop && interp->current_runloop_id != runloop_id)
+                free_runloop_jump_point(interp);
+            if (initialctx != CONTEXT(interp))
+                Parrot_warn((interp), PARROT_WARNINGS_ALL_FLAG,
+                        "find_method contexts differ!");
         }
         Parrot_cx_delete_handler_local(interp);
 


### PR DESCRIPTION
I need this to get 'nqp --target=past -e 1' working again.
