### PR TITLE
fix kFreeBSD build and probably other glibc based OS like hurd

### DIFF
--- a/3rdparty/dyncall/configure
+++ b/3rdparty/dyncall/configure
@@ -125,6 +125,8 @@ guess_os()
     CONFIG_OS="beos"
   elif [ "$OS" = "Minix" ]; then
     CONFIG_OS="minix"
+  elif [ "$OS" = "GNU/kFreeBSD" ]; then
+    CONFIG_OS="freebsd"
   fi
   info "guess operating system $CONFIG_OS"
 }

--- a/3rdparty/dyncall/dyncall/dyncall_macros.h
+++ b/3rdparty/dyncall/dyncall/dyncall_macros.h
@@ -71,7 +71,7 @@
 #define DC__OS_Linux
 
 /* The most powerful open source Unix-like OS - FreeBSD. */
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
 #define DC__OS_FreeBSD
 
 /* The most secure open source Unix-like OS - OpenBSD. */

--- a/3rdparty/dyncall/dynload/dynload_syms_elf.c
+++ b/3rdparty/dyncall/dynload/dynload_syms_elf.c
@@ -24,12 +24,6 @@
 
 */
 
-
-#if defined(OS_Linux) && !defined(_GNU_SOURCE)
-#define _GNU_SOURCE
-#define __USE_GNU
-#endif
-
 /*
  
  dynamic symbol resolver for elf
@@ -48,6 +42,12 @@
 #else
 #  include <elf.h>
 #endif
+
+#if defined(__GLIBC__)
+#define _GNU_SOURCE
+#define __USE_GNU
+#endif /* defined(__GLIBC__) */
+
 #include "dynload_alloc.h"
 
 #include <assert.h>


### PR DESCRIPTION
GNU/kFreeBSD uses the GNU libc whereas Android uses
its own libc. So OS_Linux is not reliable enough to
identify a glibc.

We use **GLIBC** to know if we are on a glibc instead of
OS_Linux.

**GLIBC** is defined by features.hi which is pulled
by the glibc headers. That's the reason why we can't
check **GLIBC** at the begining of the file.
