### PR TITLE
nicer error message of &evalfiles

### DIFF
--- a/src/HLL/Compiler.pm
+++ b/src/HLL/Compiler.pm
@@ -398,7 +398,7 @@ class HLL::Compiler {
                 pir::push(@codes, $in-handle.readall($_));
                 $in-handle.close;
                 CATCH {
-                    $err := $_;
+                    $err := "$_\n";
                 }
             }
             if $err {


### PR DESCRIPTION
pir::die prints strange error message
pir::die replaced by pir::exit and say
