### PR TITLE
Make base64.[ch] compile with new error levels

### DIFF
--- a/src/6model/base64.c
+++ b/src/6model/base64.c
@@ -4,7 +4,10 @@
 
 */
 
+#include "base64.h"
+
 #include <stdlib.h>
+#include <string.h>
 
 //  base64 encoding
 //
@@ -20,7 +23,7 @@ char* base64_encode(const void* buf, size_t size)
 	char* str = (char*) malloc((size+3)*4/3 + 1);
 
 	char* p = str;
-	unsigned char* q = (unsigned char*) buf;
+	const unsigned char* q = (const unsigned char*) buf;
 	size_t i = 0;
 
 	while (i < size) {
@@ -75,7 +78,7 @@ static int POS(char c)
 //  data_len size of decoded data
 //  return:  allocated data buffer
 //
-void* base64_decode(char* s, size_t *data_len)
+void* base64_decode(const char* s, size_t *data_len)
 {
     char *p;
     unsigned char *q, *data;
@@ -92,7 +95,7 @@ void* base64_decode(char* s, size_t *data_len)
 		n[1] = POS(*p++);
 		n[2] = POS(*p++);
 		n[3] = POS(*p++);
-        
+
         if (n[0] == -2 || n[1] == -2 || n[2] == -2 || n[3] == -2)
             return NULL;
 

--- a/src/6model/base64.h
+++ b/src/6model/base64.h
@@ -1,2 +1,9 @@
+#ifndef BASE64_H_GUARD
+#define BASE64_H_GUARD
+
+#include <stddef.h>
+
 char* base64_encode(const void* buf, size_t size);
 void* base64_decode(const char* s, size_t *data_len);
+
+#endif


### PR DESCRIPTION
Building NQP still generates ~360 warnings, but at least it'll work again...
