### PR TITLE
Toqast op hash

### DIFF
--- a/t/qast/qast.t
+++ b/t/qast/qast.t
@@ -112,6 +112,22 @@ test_qast_result(
         ok($r[1].m eq 'b', 'op list works (second elem)');
     });
 
+test_qast_result(
+    QAST::Block.new(
+        QAST::Op.new(
+            :op('hash'),
+            QAST::SVal.new(:value('a')),
+            QAST::WVal.new(:value(A)),
+            QAST::SVal.new(:value('b')),
+            QAST::WVal.new(:value(B))
+        )
+    ),
+    -> $r {
+        ok($r{'a'}.m eq 'a', 'op hash works (a keyed elem)');
+        ok($r{'b'}.m eq 'b', 'op hash works (b keyed elem)');
+    });
+
+
 is_qast(
     QAST::Block.new(
         QAST::Op.new(


### PR DESCRIPTION
Attempting to add the hash qast op (not sure if correct)

It was translated from PAST/NQP.pir with the difference being:
- the post key is coerced to s instead of to ~
- the post value is coerced to P instead of to *

So maybe it is too strict now?

The ~ and \* coercion logic didn't seem to be implemented yet however.
