### PR TITLE
fixed retrogression. 

### DIFF
--- a/src/HLL/Compiler.pm
+++ b/src/HLL/Compiler.pm
@@ -633,7 +633,7 @@ class HLL::Compiler {
 
             # If we've previously cached C<linepos> for target, we use it.
             unless cache goto linepos_build
-            linepos = getprop '!linepos', target
+            linepos = getprop target, '!linepos'
             unless null linepos goto linepos_done
 
             # calculate a new linepos array.
@@ -663,21 +663,25 @@ class HLL::Compiler {
             goto linepos_loop
           linepos_done:
 
-            # We have C<linepos>, so now we search the array for the largest
-            # element that is not greater than C<pos>.  The index of that
-            # element is the line number to be returned.
-            # (Potential optimization: use a binary search.)
-            .local int line, count
-            count = elements linepos
-            line = 0
-          line_loop:
-            if line >= count goto line_done
+            # We have C<linepos>, so now we (binary) search the array
+            # for the largest element that is not greater than C<pos>.
+            .local int lo, hi, line
+            lo = 0
+            hi = elements linepos
+          binary_loop:
+            if lo >= hi goto binary_done
+            line = lo + hi
+            line = line / 2
             $I0 = linepos[line]
-            if $I0 > pos goto line_done
-            inc line
-            goto line_loop
-          line_done:
-            .return (line)
+            if $I0 > pos goto binary_hi
+            lo = line + 1
+            goto binary_loop
+          binary_hi:
+            hi = line
+            goto binary_loop
+          binary_done:
+            inc lo
+            .return (lo)
         };
     }
 


### PR DESCRIPTION
This backports the binary search lineof optimization from PCTs HLLCompiler to HLL::Compiler.lineof again. getprop is also a retrogression, so I resurrect it. 
