### PR TITLE
fix dyncall build on Strawberry Perl

### DIFF
--- a/3rdparty/dyncall/buildsys/gmake/tool/gcc.gmake
+++ b/3rdparty/dyncall/buildsys/gmake/tool/gcc.gmake
@@ -46,16 +46,19 @@ endif
 # --- Assemble ----------------------------------------------------------------
 
 # FIXME:
-# Windows filenames are case-insensitive, ie %.s and %.S match the same files
+# Windows filenames are case-insensitive, ie %.s and %.S match the same files.
+# Additionally, mingw32-make 3.81 (which ships with older versions of
+# Strawberry Perl) is subtly different from gmake 3.82 (which ships with newer
+# ones).
 #
-# For now, just put the %.S rule after the %.s rule: apparently, GNU make will
-# execute the rule defined last, and $(COMPILE.S) works for .s files as well
-# (see dyncall/README-Developer.txt)
-
-$(BUILD_DIR)/%.o: %.s
-	$(COMPILE.s) $(OUTPUT_OPTION) $<
+# Putting the %.s rule after the %.S rule and using $(COMPILE.S) for both
+# .s and .S files (which should be ok - see dyncall/README-Developer.txt)
+# was the only combination I could get to work.
 
 $(BUILD_DIR)/%.o: %.S
+	$(COMPILE.S) $(OUTPUT_OPTION) $<
+
+$(BUILD_DIR)/%.o: %.s
 	$(COMPILE.S) $(OUTPUT_OPTION) $<
 
 #	auto-dependency: disabled, due to problems when including *.d files, see targets.gmake for details 


### PR DESCRIPTION
Tested with Strawberry Perl 5.10.1.2-32bit, 5.16.0.1-32bit, 5.14.2.1-64bit as well as Cygwin.

Should work universally, but testing on OSX would be appreciated (I don't expect anything to break, but dyncall's [README-Developer.txt](https://raw.github.com/perl6/nqp/master/3rdparty/dyncall/dyncall/README-Developer.txt) mentions that OSX uses a custom version of GNU as).

The build semantics are slightly different as the assembler is now always invoked through the gcc frontend (which should not change anything).
