### PR TITLE
more pirops to nqpops

### DIFF
--- a/docs/6model/overview.markdown
+++ b/docs/6model/overview.markdown
@@ -131,8 +131,7 @@ following.
         
         method new_type() {
             my $meta-object := self.new();
-            return pir::repr_type_object_for__PPs(
-                $meta-object, 'HashAttrStore');
+            return nqp::newtype($meta-object, 'HashAttrStore');
         }
         
         method add_method($type, $name, $code) {

--- a/examples/load_bytecode.nqp
+++ b/examples/load_bytecode.nqp
@@ -1,4 +1,4 @@
 #!nqp
 
-pir::load_bytecode('PGE.pbc');
+nqp::loadbytecode('PGE.pbc');
 say("Loaded Parrot Grammar Engine");

--- a/src/HLL/Compiler.pm
+++ b/src/HLL/Compiler.pm
@@ -205,7 +205,7 @@ class HLL::Compiler {
             %adverbs<precomp> := 1;
         }
 
-        pir::load_bytecode__vs('dumper.pbc');
+        nqp::loadbytecode('dumper.pbc');
 
         self.command_eval(|@a, |%adverbs);
     }

--- a/src/NQP/Actions.pm
+++ b/src/NQP/Actions.pm
@@ -1737,10 +1737,11 @@ class NQP::RegexActions is QRegex::P6Regex::Actions {
             self.subrule_alias($qast, $name);
         }
         elsif $name eq 'sym' {
-            my $loc := nqp::index(%*RX<name>, ':sym<');
-            $loc := nqp::index(%*RX<name>, ':sym«')
+            my str $fullrxname := %*RX<name>;
+            my int $loc := nqp::index($fullrxname, ':sym<');
+            $loc := nqp::index($fullrxname, ':sym«')
                 if $loc < 0;
-            my $rxname := pir::chopn__Ssi(nqp::substr(%*RX<name>, $loc + 5), 1);
+            my str $rxname := nqp::substr($fullrxname, $loc + 5, nqp::chars($fullrxname) - $loc - 6);
             $qast := QAST::Regex.new(:name('sym'), :rxtype<subcapture>, :node($/),
                 QAST::Regex.new(:rxtype<literal>, $rxname, :node($/)));
         }

--- a/src/NQP/World.pm
+++ b/src/NQP/World.pm
@@ -286,7 +286,7 @@ class NQP::World is HLL::World {
         }
         else {
             # Create a fresh stub code, and set its name.
-            $dummy := pir::nqp_fresh_stub__PP($stub_code);
+            $dummy := nqp::freshcoderef($stub_code);
             nqp::setcodename($dummy, $name);
             
             # Tag it as a static code ref and add it to the root code refs set.
@@ -487,10 +487,10 @@ class NQP::World is HLL::World {
         
         # Compile and run it.
         my $code := self.create_code($wrapper, 'BEGIN block', 0);
-        my $old_global := pir::get_hll_global__PPs(nqp::list(), 'GLOBAL');
-        pir::set_hll_global__vPsP(nqp::list(), 'GLOBAL', $*GLOBALish);
+        my $old_global := nqp::getcurhllsym('GLOBAL');
+        nqp::bindcurhllsym('GLOBAL', $*GLOBALish);
         $code();
-        pir::set_hll_global__vPsP(nqp::list(), 'GLOBAL', $old_global);
+        nqp::bindcurhllsym('GLOBAL', $old_global);
         
         # Need any nested blocks inside the BEGIN block to make it into the
         # output code.

--- a/src/QRegex/P5Regex/Grammar.nqp
+++ b/src/QRegex/P5Regex/Grammar.nqp
@@ -5,7 +5,7 @@ use QAST;
 class QRegex::P5Regex::World is HLL::World {
     method create_code($past, $name) {
         # Create a fresh stub code, and set its name.
-        my $dummy := pir::nqp_fresh_stub__PP(-> { nqp::die("Uncompiled code executed") });
+        my $dummy := nqp::freshcoderef(-> { nqp::die("Uncompiled code executed") });
         nqp::setcodename($dummy, $name);
 
         # Tag it as a static code ref and add it to the root code refs set.

--- a/src/QRegex/P6Regex/Grammar.nqp
+++ b/src/QRegex/P6Regex/Grammar.nqp
@@ -5,7 +5,7 @@ use QAST;
 class QRegex::P6Regex::World is HLL::World {
     method create_code($past, $name) {
         # Create a fresh stub code, and set its name.
-        my $dummy := pir::nqp_fresh_stub__PP(-> { nqp::die("Uncompiled code executed") });
+        my $dummy := nqp::freshcoderef(-> { nqp::die("Uncompiled code executed") });
         nqp::setcodename($dummy, $name);
 
         # Tag it as a static code ref and add it to the root code refs set.

--- a/t/hll/01-language.t
+++ b/t/hll/01-language.t
@@ -4,7 +4,7 @@ use NQPHLL;
 
 plan(2);
 
-ok( pir::compreg__Ps('parrot') ~~ HLL::Compiler, 'compreg for Parrot returns a HLL::Compiler' );
+ok( nqp::getcomp('parrot') ~~ HLL::Compiler, 'compreg for Parrot returns a HLL::Compiler' );
 
-ok( pir::compreg__Ps('parrot').language eq 'parrot', '.language gives "parrot"' );
+ok( nqp::getcomp('parrot').language eq 'parrot', '.language gives "parrot"' );
 

--- a/t/hll/02-modules.t
+++ b/t/hll/02-modules.t
@@ -4,7 +4,7 @@ say("1..0 skip design changes, need re-work");
 
 # plan(4);
 #
-#my $parrot-comp := pir::compreg__Ps('parrot');#
+#my $parrot-comp := nqp::getcomp('parrot');#
 #
 #my $comp := $parrot-comp.get_module('HLL::Compiler');
 #ok($comp =:= $parrot-comp.WHO, "correctly retrieved namespace");#

--- a/t/hll/03-exports.t
+++ b/t/hll/03-exports.t
@@ -13,7 +13,7 @@ say("1..0 skip design changes (EXPORT now lexical), need re-work");
 #&ABC::EXPORT::DEFAULT::alpha := &ABC::alpha;
 #$ABC::EXPORT::DEFAULT::gamma := $ABC::gamma;
 #
-#my $parrot-comp := pir::compreg__Ps('nqp');
+#my $parrot-comp := nqp::getcomp('nqp');
 #
 #my $module := $parrot-comp.get_module('ABC');
 #my %exports := $parrot-comp.get_exports($module);

--- a/t/hll/04-import.t
+++ b/t/hll/04-import.t
@@ -13,7 +13,7 @@ say("1..0 skip design changes (EXPORT now lexical), need re-work");
 #ABC::EXPORT::DEFAULT::alpha := ABC::alpha;
 #$ABC::EXPORT::DEFAULT::gamma := $ABC::gamma;
 #
-#my $parrot-comp := pir::compreg__Ps('nqp');
+#my $parrot-comp := nqp::getcomp('nqp');
 #
 #my $module := $parrot-comp.get_module('ABC');
 #my %exports := $parrot-comp.get_exports($module);

--- a/t/p5regex/01-p5regex.t
+++ b/t/p5regex/01-p5regex.t
@@ -37,7 +37,7 @@ sub test_line($line) {
                            ?? pir::chopn__Ssi(nqp::substr($expect, 1), 1)
                            !! '';
 
-    my $rxcomp := pir::compreg__Ps('QRegex::P5Regex');
+    my $rxcomp := nqp::getcomp('QRegex::P5Regex');
     try {
         my $rxsub  := $rxcomp.compile($regex);
         my $cursor := NQPCursor."!cursor_init"($target, :c(0));

--- a/t/qregex/01-qregex.t
+++ b/t/qregex/01-qregex.t
@@ -43,7 +43,7 @@ sub test_line($line) {
                            ?? pir::chopn__Ssi(nqp::substr($expect, 1), 1)
                            !! '';
 
-    my $rxcomp := pir::compreg__Ps('QRegex::P6Regex');
+    my $rxcomp := nqp::getcomp('QRegex::P6Regex');
     try {
         my $rxsub  := $rxcomp.compile($regex);
         my $cursor := NQPCursor."!cursor_init"($target, :c(0));

--- a/t/serialization/01-basic.t
+++ b/t/serialization/01-basic.t
@@ -317,7 +317,7 @@ plan(66);
             $obj;
         }
         method BUILD() {
-            my @a := pir::new__Ps('ResizableIntegerArray');
+            my @a := nqp::list_i();
             @a[0] := 101;
             @a[1] := 102;
             @a[2] := 103;

--- a/t/serialization/02-types.t
+++ b/t/serialization/02-types.t
@@ -114,8 +114,8 @@ plan(31);
     
     my $m1 := method () { "awful" };
     my $m2 := method () { "Hi, I'm " ~ nqp::getattr(self, self.WHAT, '$!name') };
-    pir::nqp_add_code_ref_to_sc__vPiP($sc, 0, $m1);
-    pir::nqp_add_code_ref_to_sc__vPiP($sc, 1, $m2);
+    nqp::scsetcode($sc, 0, $m1);
+    nqp::scsetcode($sc, 1, $m2);
     pir::setprop__vPsP($m1, 'STATIC_CODE_REF', $m1);
     pir::setprop__vPsP($m2, 'STATIC_CODE_REF', $m2);
     

--- a/t/serialization/03-closures.t
+++ b/t/serialization/03-closures.t
@@ -11,7 +11,7 @@ plan(9);
     my $sh := nqp::list_s();
     
     my $m1 := (method () { "success!" }).get_lexinfo().get_static_code();
-    pir::nqp_add_code_ref_to_sc__vPiP($sc, 0, $m1);
+    nqp::scsetcode($sc, 0, $m1);
     pir::setprop__vPsP($m1, 'STATIC_CODE_REF', $m1);
     
     # Here we make a clone of it, which is what we're testing.
@@ -52,11 +52,11 @@ plan(9);
     # one more invocation just to avoid getting lucky...
     $raw_sub('XXX');
     
-    pir::nqp_add_code_ref_to_sc__vPiP($sc, 0, $raw_sub);
+    nqp::scsetcode($sc, 0, $raw_sub);
     pir::setprop__vPsP($raw_sub, 'STATIC_CODE_REF', $raw_sub);
     
     my $raw_meth := $m1.get_lexinfo().get_static_code();
-    pir::nqp_add_code_ref_to_sc__vPiP($sc, 1, $raw_meth);
+    nqp::scsetcode($sc, 1, $raw_meth);
     pir::setprop__vPsP($raw_meth, 'STATIC_CODE_REF', $raw_meth);
     
     my $type1 := pir::get_knowhow__P().new_type(:name('RoleLikeTest1'), :repr('P6opaque'));


### PR DESCRIPTION
passes nqp test & rakudo spectests

With this there are about ~70-ish pir:: occurances left in the nqp repo (without counting the ones in docs, string literals or parts of method names)
