### PR TITLE
Added remaining bigint nqp ops

### DIFF
--- a/src/vm/jvm/QAST/Compiler.nqp
+++ b/src/vm/jvm/QAST/Compiler.nqp
@@ -1577,6 +1577,8 @@ QAST::OperationsJAST.map_jvm_core_op('div_n', 'ddiv', [$RT_NUM, $RT_NUM], $RT_NU
 QAST::OperationsJAST.map_jvm_core_op('mod_i', 'lrem', [$RT_INT, $RT_INT], $RT_INT);
 QAST::OperationsJAST.map_classlib_core_op('mod_I', $TYPE_OPS, 'mod_I', [$RT_OBJ, $RT_OBJ, $RT_OBJ], $RT_OBJ, :tc);
 QAST::OperationsJAST.map_classlib_core_op('expmod_I', $TYPE_OPS, 'expmod_I', [$RT_OBJ, $RT_OBJ, $RT_OBJ, $RT_OBJ], $RT_OBJ, :tc);
+QAST::OperationsJAST.map_classlib_core_op('isprime_I', $TYPE_OPS, 'isprime_I', [$RT_OBJ, $RT_INT], $RT_INT, :tc);
+QAST::OperationsJAST.map_classlib_core_op('rand_I', $TYPE_OPS, 'rand_I', [$RT_OBJ, $RT_OBJ], $RT_OBJ, :tc);
 QAST::OperationsJAST.map_jvm_core_op('mod_n', 'drem', [$RT_NUM, $RT_NUM], $RT_NUM);
 QAST::OperationsJAST.map_classlib_core_op('pow_n', $TYPE_MATH, 'pow', [$RT_NUM, $RT_NUM], $RT_NUM);
 QAST::OperationsJAST.map_classlib_core_op('pow_I', $TYPE_OPS, 'pow_I', [$RT_OBJ, $RT_OBJ, $RT_OBJ, $RT_OBJ], $RT_OBJ, :tc);
@@ -1612,7 +1614,9 @@ QAST::OperationsJAST.map_classlib_core_op('sech_n', $TYPE_OPS, 'sech_n', [$RT_NU
 
 # esoteric math opcodes
 QAST::OperationsJAST.map_classlib_core_op('gcd_i', $TYPE_OPS, 'gcd_i', [$RT_INT, $RT_INT], $RT_INT);
+QAST::OperationsJAST.map_classlib_core_op('gcd_I', $TYPE_OPS, 'gcd_I', [$RT_OBJ, $RT_OBJ, $RT_OBJ], $RT_OBJ, :tc);
 QAST::OperationsJAST.map_classlib_core_op('lcm_i', $TYPE_OPS, 'lcm_i', [$RT_INT, $RT_INT], $RT_INT);
+QAST::OperationsJAST.map_classlib_core_op('lcm_I', $TYPE_OPS, 'lcm_I', [$RT_OBJ, $RT_OBJ, $RT_OBJ], $RT_OBJ, :tc);
 
 # string opcodes
 QAST::OperationsJAST.map_classlib_core_op('chars', $TYPE_OPS, 'chars', [$RT_STR], $RT_INT);

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 import org.perl6.nqp.jast2bc.JASTToJVMBytecode;
@@ -1973,8 +1974,19 @@ public final class Ops {
                 .longValue();
     }
 
+    public static SixModelObject gcd_I(SixModelObject a, SixModelObject b, SixModelObject type, ThreadContext tc) {
+        return makeBI(tc, type, getBI(tc, a).gcd(getBI(tc, b)));
+    }
+    
     public static long lcm_i(long valA, long valB) {
         return valA * (valB / gcd_i(valA, valB));
+    }
+    
+    public static SixModelObject lcm_I(SixModelObject a, SixModelObject b, SixModelObject type, ThreadContext tc) {
+        BigInteger valA = getBI(tc, a);
+        BigInteger valB = getBI(tc, b);
+        BigInteger gcd = valA.gcd(valB);
+        return makeBI(tc, type, valA.multiply(valB).divide(gcd));
     }
     
     public static SixModelObject radix(long radix, String str, long zpos, long flags, ThreadContext tc) {
@@ -3342,6 +3354,20 @@ public final class Ops {
     
     public static SixModelObject expmod_I(SixModelObject a, SixModelObject b, SixModelObject c, SixModelObject type, ThreadContext tc) {
         return makeBI(tc, type, getBI(tc, a).modPow(getBI(tc, b), getBI(tc, c)));
+    }
+    
+    public static long isprime_I(SixModelObject a, long certainty, ThreadContext tc) {
+        BigInteger bi = getBI(tc, a);
+        if (bi.compareTo(BigInteger.valueOf(1)) <= 0) {
+            return 0;
+    	}
+        return bi.isProbablePrime((int)certainty) ? 1 : 0;
+    }
+    
+    public static SixModelObject rand_I(SixModelObject a, SixModelObject type, ThreadContext tc) {
+        BigInteger size = getBI(tc, a);
+        BigInteger random = new BigInteger(size.bitLength(), ThreadLocalRandom.current()).mod(size);
+        return makeBI(tc, type, random);
     }
     
     public static SixModelObject pow_I(SixModelObject a, SixModelObject b, SixModelObject biType, SixModelObject nType, ThreadContext tc) {

--- a/t/nqp/60-bigint.t
+++ b/t/nqp/60-bigint.t
@@ -1,7 +1,7 @@
 #! nqp
 use nqpmo;
 
-plan(36);
+plan(45);
 
 my $knowhow := nqp::knowhow();
 my $bi_type := $knowhow.new_type(:name('TestBigInt'), :repr('P6bigint'));
@@ -107,3 +107,17 @@ my $n := nqp::div_In(
     nqp::pow_I(box(200), box(200), $bi_type, $bi_type),
 );
 ok(nqp::abs_n($n - 19.6430286394751) < 1e-10, 'div_In with big numbers');
+
+my $maxRand := nqp::fromstr_I('10000000000000000000000000000000000000000', $bi_type);
+my $rand := nqp::rand_I($maxRand, $bi_type); 
+ok(nqp::isle_I(box(0), $rand) && nqp::islt_I($rand, $maxRand), 'nqp::rand_I');
+
+ok(nqp::isprime_I(box(-4), 1) == 0, 'is -4 prime');
+ok(nqp::isprime_I(box(0), 1) == 0, 'is 0 prime');
+ok(nqp::isprime_I(box(1), 1) == 0, 'is 1 prime');
+ok(nqp::isprime_I(box(2), 1) == 1, 'is 2 prime');
+ok(nqp::isprime_I(box(4), 1) == 0, 'is 4 prime');
+ok(nqp::isprime_I(box(17), 1) == 1, 'is 17 prime');
+
+ok(nqp::iseq_I(nqp::gcd_I(box(18), box(12), $bi_type), box(6)), 'nqp::gcd_I');
+ok(nqp::iseq_I(nqp::lcm_I(box(18), box(12), $bi_type), box(36)), 'nqp::lcm_I');


### PR DESCRIPTION
nqp::rand_I, nqp::isprime_I, nqp::gcd_I and nqp::lcm_I added with tests. Tests pass on both parrot and jvm.
