### PR TITLE
Restore --dynext processing for Parrot

### DIFF
--- a/src/NQP/World.nqp
+++ b/src/NQP/World.nqp
@@ -33,6 +33,15 @@ class NQP::World is HLL::World {
         %!code_object_fixup_list := nqp::hash();
         %!code_stub_sc_idx := nqp::hash();
         @!clearup_tasks := nqp::list();
+
+#?if parrot
+        if nqp::defined(%*COMPILING<%?OPTIONS><dynext>) {
+            my $dynext_path  := %*COMPILING<%?OPTIONS><dynext>;
+            my @dynext_paths := pir::getinterp__P()[pir::const::IGLOBALS_LIB_PATHS][pir::const::PARROT_LIB_PATH_DYNEXT];
+
+            @dynext_paths.push($dynext_path);
+        }
+#?endif
     }
     
     # Creates a new lexical scope and puts it on top of the stack.


### PR DESCRIPTION
The included code is essentially a revert for a commit that happened in February that made it easier to build packages for Rakudo star.
