### PR TITLE
Pass %*ENV contents into ProcessBuilder in nqp::shell

### DIFF
--- a/src/vm/jvm/QAST/Compiler.nqp
+++ b/src/vm/jvm/QAST/Compiler.nqp
@@ -1907,7 +1907,7 @@ QAST::OperationsJAST.map_classlib_core_op('mkdir', $TYPE_OPS, 'mkdir', [$RT_STR,
 QAST::OperationsJAST.map_classlib_core_op('rename', $TYPE_OPS, 'rename', [$RT_STR, $RT_STR], $RT_INT);
 QAST::OperationsJAST.map_classlib_core_op('copy', $TYPE_OPS, 'copy', [$RT_STR, $RT_STR], $RT_INT);
 QAST::OperationsJAST.map_classlib_core_op('link', $TYPE_OPS, 'link', [$RT_STR, $RT_STR], $RT_INT);
-QAST::OperationsJAST.map_classlib_core_op('shell', $TYPE_OPS, 'shell', [$RT_STR], $RT_INT);
+QAST::OperationsJAST.map_classlib_core_op('shell', $TYPE_OPS, 'shell', [$RT_STR], $RT_INT, :tc);
 QAST::OperationsJAST.map_classlib_core_op('symlink', $TYPE_OPS, 'symlink', [$RT_STR, $RT_STR], $RT_INT);
 
 QAST::OperationsJAST.map_classlib_core_op('opendir', $TYPE_OPS, 'opendir', [$RT_STR], $RT_OBJ, :tc);

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/GlobalContext.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/GlobalContext.java
@@ -194,6 +194,8 @@ public class GlobalContext {
 
     ThreadLocal<WeakReference<ThreadContext>> currentThreadCtxRef;
     WeakHashMap<Thread, ThreadContext> allThreads;
+    
+    public SixModelObject processEnvironment = null;
 
     /**
      * Initializes the runtime environment.


### PR DESCRIPTION
This fixes a spectest in S02-magicals/env.t - ENV members persist to child processes
