### PR TITLE
thinko on unicode surrogate range

### DIFF
--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
@@ -2753,8 +2753,7 @@ public final class Ops {
                 || ((val & 0xfffe) == 0xfffe)     // non character
                 || val > 0x10ffff)                // out of range
             )
-        || (val >= 0xd800 && val <= 0xdbff)    // high surrogate
-        || (val >= 0xdc00 && val <= 0xdcff)    // low surrogate
+        || (val >= 0xd800 && val <= 0xdfff)       // surrogate
         ) {
             throw ExceptionHandling.dieInternal(tc, "Invalid code-point U+" + String.format("%05X", val));
         }


### PR DESCRIPTION
Lower and and high surrogate ranges are adjacent. So these two comparisons can be combined. Also high surrogates end at 0xdfff, not 0xdcff.
