### PR TITLE
classify char as newline: U+0085 NEXT LINE (NEL)

### DIFF
--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
@@ -3146,7 +3146,7 @@ public final class Ops {
             return test == '_' || Character.isLetterOrDigit(test) ? 1 : 0;
         case CCLASS_NEWLINE:
             return (Character.getType(test) == Character.LINE_SEPARATOR) ||
-                    (test == '\n' || test == '\r')
+                    (test == '\n' || test == '\r' || test == '\u0085')
                     ? 1 : 0;
         case CCLASS_ALPHABETIC:
             return Character.isAlphabetic(test) ? 1 : 0;


### PR DESCRIPTION
Fixes roast failures:
S05-metachars/newline.rakudo.jvm 6 - NEL
S05-metachars/newline.rakudo.jvm 13 - not NEL
