### PR TITLE
Let nqp-j work even if CLASSPATH is set

### DIFF
--- a/src/vm/jvm/runners/nqp-j
+++ b/src/vm/jvm/runners/nqp-j
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec java -Xbootclasspath/a:.:nqp-runtime.jar:3rdparty/asm/asm-4.1.jar:3rdparty/jline/jline-1.0.jar:3rdparty/jna/jna.jar:nqp.jar nqp "$@"
+exec java -cp . -Xbootclasspath/a:.:nqp-runtime.jar:3rdparty/asm/asm-4.1.jar:3rdparty/jline/jline-1.0.jar:3rdparty/jna/jna.jar:nqp.jar nqp "$@"

--- a/src/vm/jvm/runners/nqp-j.bat
+++ b/src/vm/jvm/runners/nqp-j.bat
@@ -1,1 +1,1 @@
-@java -Xbootclasspath/a:.;nqp-runtime.jar;3rdparty/asm/asm-4.1.jar;3rdparty/jline/jline-1.0.jar;3rdparty/jna/jna.jar;nqp.jar nqp %*
+@java -cp . -Xbootclasspath/a:.;nqp-runtime.jar;3rdparty/asm/asm-4.1.jar;3rdparty/jline/jline-1.0.jar;3rdparty/jna/jna.jar;nqp.jar nqp %*


### PR DESCRIPTION
This fixes the issue where if a CLASSPATH environment variable was set, nqp-j would fail while building NQP.
