### PR TITLE
Update Configure.pm

### DIFF
--- a/tools/lib/NQP/Configure.pm
+++ b/tools/lib/NQP/Configure.pm
@@ -29,9 +29,9 @@ our @required_nqp_files = qw(
     @bindir@/nqp-p@exe@
 );
 
-our $nqp_git = 'https://github.com/perl6/nqp.git';
-our $par_git = 'https://github.com/parrot/parrot.git';
-our $moar_git= 'https://github.com/MoarVM/MoarVM.git';
+our $nqp_git = 'git://github.com/perl6/nqp.git';
+our $par_git = 'git://github.com/parrot/parrot.git';
+our $moar_git= 'git://github.com/MoarVM/MoarVM.git';
 
 our $nqp_push = 'git@github.com:perl6/nqp.git';
 our $par_push = 'git@github.com:parrot/parrot.git';


### PR DESCRIPTION
Use git instead of https, so that nqp can be built on systems where curl-devel packages can't be installed.
