### PR TITLE
add CFLAGS=-fPIC to compile dyncall for backend gen-parrot on FreeBSD

### DIFF
--- a/3rdparty/dyncall/configure
+++ b/3rdparty/dyncall/configure
@@ -51,6 +51,9 @@ case ${TARGET:=`uname`} in
     printf "LDFLAGS=-lm\n" >>$C
     ;;
   FreeBSD)
+    if [ -z "${CFLAGS}" ]; then
+      printf "CFLAGS=-fPIC\n" >>$C
+    fi
     printf "LDFLAGS=-lm\n" >>$C
     printf "RM=rm -f\n" >>$C
     ;;


### PR DESCRIPTION
In order to install perl6-p on FreeBSD 10.0 I had to compile dyncall with CFLAGS=-fPIC.
I think this was the same problem ChoHag++ reported earlier on #perl6:
- http://irclog.perlgeek.de/perl6/2014-06-10#i_8847415
- http://irclog.perlgeek.de/perl6/2014-06-10#i_8847228

After I figured this out I took a look at the public svn repository at dyncall.org:
$ diff --context=1 \
<(curl -s http://dyncall.org/svn/dyncall/tags/r0.8/dyncall/configure) \
<(curl -s http://dyncall.org/svn/dyncall/trunk/dyncall/configure)
**\* /dev/fd/63  2014-09-18 15:31:12.136867943 +0200
--- /dev/fd/62  2014-09-18 15:31:12.136867943 +0200

---

**\* 19,21 ****
    case $X in
!     --help|-h)
  cat <<EOF
--- 19,21 ----
    case $X in
!     --help|-h|-?)
  cat <<EOF

---

**\* 64,65 ****
--- 64,68 ----
    FreeBSD)
-     if [ -z "${CFLAGS}" ]; then
-       printf "CFLAGS=-fPIC\n" >>$C
-     fi
    printf "LDFLAGS=-lm\n" >>$C

That makes me confident that my patch is good enough ;-)
