### PR TITLE
compile dyncall with -fPIC on DragonFly BSD

### DIFF
--- a/3rdparty/dyncall/configure
+++ b/3rdparty/dyncall/configure
@@ -50,6 +50,11 @@ case ${TARGET:=`uname`} in
   OpenBSD)
     printf "LDFLAGS=-lm\n" >>$C
     ;;
+  DragonFly)
+    if [ -z "${CFLAGS}" ]; then
+      printf "CFLAGS=-fPIC\n" >>$C
+    fi
+    ;;
   NetBSD)
     if [ -z "${CFLAGS}" ]; then
       printf "CFLAGS=-fPIC\n" >>$C


### PR DESCRIPTION
This fixes a build problem on DragonFly BSD.
It's the same fix as in commit 5ed99d26b3c3ac2d65bc622afdbd987a547046f5 for FreeBSD and 008f60c31bbd82ca090486468e8ffc8cd51bfb11 for NetBSD.

Properly all this changes should be reported upstream (to the dyncall developer).
FreeBSD, NetBSD and Dragonfly BSD need the -fPIC compiler flag. OpenBSD has Position Independent Code enabled since version 5.3 and therefor doesn't need the flag.
