### PR TITLE
on MacPorts need to enforce system /usr/bin/libtool for -static

### DIFF
--- a/3rdparty/dyncall/configure
+++ b/3rdparty/dyncall/configure
@@ -69,7 +69,8 @@ case ${TARGET:=`uname`} in
     printf "RM=rm -f\n" >>$C
     ;;
   MacOSX|Darwin)
-    printf "AR=libtool\n" >>$C
+    # MacPorts libtool cannot do -static, use the system libtool
+    printf "AR=/usr/bin/libtool\n" >>$C
     printf "ARFLAGS=-static -o\n" >>$C
     if [ `uname -n` = 'iPhone' ]; then # building on iPhone itself, uname yields Darwin (gcc setup for current/correct arch)
       printf "CC=gcc\n" >>$C


### PR DESCRIPTION
error message: libtool: unrecognized option `-static
libtool: Try`libtool --help' for more information.
because on macports libtool is taken from /opt/local/bin.
-static is a xcode-only aberation.

also posted to the dyncall-talk mailinglist, but didn't see it in the archives there yet
