### PR TITLE
Add support for multiple -e args for NQP and thus Perl 6.

### DIFF
--- a/src/HLL/Compiler.nqp
+++ b/src/HLL/Compiler.nqp
@@ -132,7 +132,7 @@ class HLL::Compiler does HLL::Backend::Default {
         my $output;
 
         if nqp::islist($code) {
-            $code := nqp::join('', $code);
+            $code := nqp::join("\n", $code);
         }
 
         if (%adverbs<profile-compile>) {


### PR DESCRIPTION
For [reference](https://rt.perl.org/Ticket/Display.html?id=73790). 
Additionally this disallows multiple instances of a few others options, namely target, optimize, encoding and output.
