### PR TITLE
Add support for loading bare .class files and increase visibility for a few BootJavaInterop fields and inner class constructors.

### DIFF
--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/BootJavaInterop.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/BootJavaInterop.java
@@ -666,6 +666,7 @@ public class BootJavaInterop {
 
     /** Stores working information while building a class. */
     protected static class ClassContext {
+        public ClassContext() {}
         /** The ASM class writer. */
         public ClassWriter cv;
         /** The new class' internal name. */
@@ -825,6 +826,7 @@ public class BootJavaInterop {
 
     /** Working information for a method under construction. */
     protected static class MethodContext {
+        public MethodContext() { }
         /** The owning incomplete class. */
         public ClassContext cc;
         /** The ASM method writer. */

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/SixModelObject.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/SixModelObject.java
@@ -86,7 +86,7 @@ public abstract class SixModelObject implements Cloneable {
         throw ExceptionHandling.dieInternal(tc, this.st.REPR.name + " representation does not implement bind_pos_boxed");
     }
     public void bind_pos_native(ThreadContext tc, long index) {
-        throw ExceptionHandling.dieInternal(tc, this.st.REPR.name + " representation does not implement bind_pos_boxed_native");
+        throw ExceptionHandling.dieInternal(tc, this.st.REPR.name + " representation does not implement bind_pos_native");
     }
     public void set_elems(ThreadContext tc, long count) {
         throw ExceptionHandling.dieInternal(tc, this.st.REPR.name + " representation does not implement set_elems");


### PR DESCRIPTION
The increased visibility is a neccessity for the branch that improves JVM-Interop on Rakudo, while loading of bare .class files was just incomplete.