### PR TITLE
Do not try to intify a missing argument

### DIFF
--- a/src/HLL/sprintf.nqp
+++ b/src/HLL/sprintf.nqp
@@ -89,6 +89,9 @@ my module sprintf {
         }
 
         sub intify($number_representation) {
+            if $number_representation =:= NQPMu {
+                return $zero;   ## missing argument is handled in method TOP
+            }
             for @handlers -> $handler {
                 if $handler.mine($number_representation) {
                     return $handler.int($number_representation);


### PR DESCRIPTION
return zero instead and let the check for the right number of arguments
do its job later on

fixes RT #122907