### PR TITLE
Fix EOF with newlines on 32k byte boundaries

### DIFF
--- a/src/vm/jvm/runtime/org/perl6/nqp/io/FileHandle.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/io/FileHandle.java
@@ -87,11 +87,8 @@ public class FileHandle extends SyncHandle implements IIOSeekable {
             return false;
         else {
             try {
-                long position = fc.position();
-                getc(tc);
-                fc.position(position);
-                readBuffer = null;
-                return false;
+                eof = fc.position() >= fc.size();
+                return eof;
             }
             catch (Exception e) {
                 eof = true;


### PR DESCRIPTION
Fixes #224 by changing the EOF checking to use the size of the file
rather than attempting to read a character using getc(). This fixes a
problem which happens when a line ends on a multiple of 32768 bytes.

I tested this via NQP's make test, ran a spectest on Rakudo (which had several failures but none that looked related), and tested manually. I only tested on regular files on Linux.