### PR TITLE
[jvm] Implement nqp::readlink

### DIFF
--- a/src/vm/jvm/QAST/Compiler.nqp
+++ b/src/vm/jvm/QAST/Compiler.nqp
@@ -1995,6 +1995,7 @@ QAST::OperationsJAST.map_classlib_core_op('print', $TYPE_OPS, 'print', [$RT_STR]
 QAST::OperationsJAST.map_classlib_core_op('say', $TYPE_OPS, 'say', [$RT_STR], $RT_STR, :tc);
 QAST::OperationsJAST.map_classlib_core_op('stat', $TYPE_OPS, 'stat', [$RT_STR, $RT_INT], $RT_INT);
 QAST::OperationsJAST.map_classlib_core_op('open', $TYPE_OPS, 'open', [$RT_STR, $RT_STR], $RT_OBJ, :tc);
+QAST::OperationsJAST.map_classlib_core_op('readlink', $TYPE_OPS, 'readlink', [$RT_STR], $RT_STR, :tc);
 QAST::OperationsJAST.map_classlib_core_op('filereadable', $TYPE_OPS, 'filereadable', [$RT_STR], $RT_INT, :tc);
 QAST::OperationsJAST.map_classlib_core_op('filewritable', $TYPE_OPS, 'filewritable', [$RT_STR], $RT_INT, :tc);
 QAST::OperationsJAST.map_classlib_core_op('fileexecutable', $TYPE_OPS, 'fileexecutable', [$RT_STR], $RT_INT, :tc);

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
@@ -16,6 +16,7 @@ import java.nio.charset.Charset;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
+import java.nio.file.NotLinkException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
@@ -626,6 +627,16 @@ public final class Ops {
             die_s("flushfh requires an object with the IOHandle REPR", tc);
         }
         return obj;
+    }
+
+    public static String readlink(String path, ThreadContext tc) {
+        try {
+            return Files.readSymbolicLink(new File(path).toPath()).toString();
+        } catch (NotLinkException e) {
+            throw ExceptionHandling.dieInternal(tc, path + " is not a symbolic link");
+        } catch (IOException e) {
+            throw ExceptionHandling.dieInternal(tc, "Failed to readlink file: " + e);
+        }
     }
 
     public static String readlinefh(SixModelObject obj, ThreadContext tc) {


### PR DESCRIPTION
Tested on Linux only with a symlink. Seems to match nqp-m's behavior for a regular symlink, a dangling symlink, regular files, and non-existent files.