### PR TITLE
Unlink tmp file after tests

### DIFF
--- a/t/nqp/19-file-ops.t
+++ b/t/nqp/19-file-ops.t
@@ -167,12 +167,12 @@ nqp::unlink($test-file ~ '-linked');
 
 # symlink
 
-my $tmp_file := "tmp";
+my $tmp-file := "tmp";
 my $env := nqp::getenvhash();
 $env<NQP_SHELL_TEST_ENV_VAR> := "123foo";
-nqp::shell("echo %NQP_SHELL_TEST_ENV_VAR% > $tmp_file",nqp::cwd(),$env);
-my $output := slurp($tmp_file);
-nqp::unlink($tmp_file);
+nqp::shell("echo %NQP_SHELL_TEST_ENV_VAR% > $tmp-file",nqp::cwd(),$env);
+my $output := slurp($tmp-file);
+nqp::unlink($tmp-file);
 my $is-windows := $output ne "%NQP_SHELL_TEST_ENV_VAR%\n";
 
 if $is-windows {

--- a/t/nqp/19-file-ops.t
+++ b/t/nqp/19-file-ops.t
@@ -172,6 +172,7 @@ my $env := nqp::getenvhash();
 $env<NQP_SHELL_TEST_ENV_VAR> := "123foo";
 nqp::shell("echo %NQP_SHELL_TEST_ENV_VAR% > $tmp_file",nqp::cwd(),$env);
 my $output := slurp($tmp_file);
+nqp::unlink($tmp_file);
 my $is-windows := $output ne "%NQP_SHELL_TEST_ENV_VAR%\n";
 
 if $is-windows {

--- a/t/nqp/78-shell.t
+++ b/t/nqp/78-shell.t
@@ -26,3 +26,4 @@ if $output eq "%NQP_SHELL_TEST_ENV_VAR%\n" {
 } else {
   ok($output ~~ /^123foo/,"passing env variables to child processes works on windows");
 }
+nqp::unlink($tmp_file);

--- a/t/nqp/78-shell.t
+++ b/t/nqp/78-shell.t
@@ -9,21 +9,21 @@ ok(nqp::ishash($a),'nqp::getenvhash() returns a hash');
 ok($a<foo> == 123,'nqp::getenvhash() is a fresh hash');
 ok($b<foo> == 456,'nqp::getenvhash() is a fresh hash');
 
-my $tmp_file := "tmp";
-nqp::shell("echo Hello > $tmp_file",nqp::cwd(),nqp::getenvhash());
-my $output := slurp($tmp_file);
+my $tmp-file := "tmp";
+nqp::shell("echo Hello > $tmp-file",nqp::cwd(),nqp::getenvhash());
+my $output := slurp($tmp-file);
 ok($output ~~ /^Hello/,'nqp::shell works with the echo shell command');
 
 my $env := nqp::getenvhash();
 $env<NQP_SHELL_TEST_ENV_VAR> := "123foo";
 
-nqp::shell("echo %NQP_SHELL_TEST_ENV_VAR% > $tmp_file",nqp::cwd(),$env);
-$output := slurp($tmp_file);
+nqp::shell("echo %NQP_SHELL_TEST_ENV_VAR% > $tmp-file",nqp::cwd(),$env);
+$output := slurp($tmp-file);
 if $output eq "%NQP_SHELL_TEST_ENV_VAR%\n" {
-    nqp::shell("echo \$NQP_SHELL_TEST_ENV_VAR > $tmp_file",nqp::cwd(),$env);
-    my $output := slurp($tmp_file);
+    nqp::shell("echo \$NQP_SHELL_TEST_ENV_VAR > $tmp-file",nqp::cwd(),$env);
+    my $output := slurp($tmp-file);
     ok($output eq "123foo\n","passing env variables to child processes works linux");
 } else {
   ok($output ~~ /^123foo/,"passing env variables to child processes works on windows");
 }
-nqp::unlink($tmp_file);
+nqp::unlink($tmp-file);


### PR DESCRIPTION
Clean up the automatically generated "tmp" file which is created while running the test suite.