### PR TITLE
An attempt to reduce --profile's memory usage

### DIFF
--- a/src/HLL/Compiler.nqp
+++ b/src/HLL/Compiler.nqp
@@ -134,7 +134,7 @@ class HLL::Compiler does HLL::Backend::Default {
         if (%adverbs<profile-compile>) {
             $output := $!backend.run_profiled({
                 self.compile($code, :compunit_ok(1), |%adverbs);
-            });
+            }, %adverbs<profile-filename>);
         }
         else {
             $output := self.compile($code, :compunit_ok(1), |%adverbs);


### PR DESCRIPTION
[timotimo asked in `#perl6`](http://irclog.perlgeek.de/perl6/2015-04-17#i_10460782) for volunteers to try running `--profile-compile` on CORE.setting.

I should've known better, but did it anyway and it did horrible OOM things to every system I tried it on. So this change makes it not do that - it now (barely) runs with about a dozen gigabytes of virtual memory.

I've also added a way to get the raw JSON without wrapping it in the HTML GUI (that's still the default). Reasoning for this is in the commit message.