### PR TITLE
Removed setting the input line separator

### DIFF
--- a/src/HLL/Compiler.nqp
+++ b/src/HLL/Compiler.nqp
@@ -393,9 +393,6 @@ class HLL::Compiler does HLL::Backend::Default {
         my $result := $source;
         my $stderr := nqp::getstderr();
         my $stdin  := nqp::getstdin();
-#?if moar
-        nqp::setinputlinesep($stdin, "\n");
-#?endif
         my $stagestats := %adverbs<stagestats>;
         unless $from eq '' || self.exists_stage($from) {
             nqp::die("Unknown compilation input '$from'");


### PR DESCRIPTION
Removing this allows the Perl 6 REPL to function in Windows once again since the line separator is handled in rakudo/src/core/IO/Handle.pm anyway.