### PR TITLE
Update Makefile-common.in to work with mingw

### DIFF
--- a/tools/build/Makefile-common.in
+++ b/tools/build/Makefile-common.in
@@ -98,6 +98,7 @@ CHMOD         = $(PERL) -MExtUtils::Command -e chmod
 CP            = $(PERL) -MExtUtils::Command -e cp
 RM_RF         = $(PERL) -MExtUtils::Command -e rm_rf
 RM_F          = $(PERL) -MExtUtils::Command -e rm_f
+SHELL         = @shell@
 
 SYSROOT         = @sysroot@
 PREFIX          = @prefix@


### PR DESCRIPTION
Fix /bin/sh: C:Strawberryperlbinperl.exe: command not found errors with mingw build without (hopefully) breaking other builds.

Tested with Ubuntu Linux, Windows 7 cmd and Windows 7 x64 Native Tools Command prompt.  Ran make/nmake test for all cases with only two subtests failing in one test file in Windows 7 cmd - presumably unrelated failures in t\hll/06-sprintf.t.

Hopefully one more step in working towards a smooth mingw build of rakudo.