### PR TITLE
Make HLL::Compiler::readline chomp

### DIFF
--- a/src/HLL/Compiler.nqp
+++ b/src/HLL/Compiler.nqp
@@ -54,7 +54,7 @@ class HLL::Compiler does HLL::Backend::Default {
 
     method readline($stdin, $stdout, $prompt) {
         nqp::printfh(nqp::getstdout(), $prompt);
-        return nqp::readlinefh($stdin);
+        return nqp::readlinechompfh($stdin);
     }
 
     method context() {


### PR DESCRIPTION
Continued statement detection in `interactive` expects that any code read in
will have had the line separator removed, which is what Linenoise (and 
presumably Readline) do. However, the fallback readline doesn't. 

This fixes that.