### PR TITLE
Retain newlines in continued code

### DIFF
--- a/src/HLL/Compiler.nqp
+++ b/src/HLL/Compiler.nqp
@@ -88,7 +88,8 @@ class HLL::Compiler does HLL::Backend::Default {
 
             if $newcode && nqp::substr($newcode, nqp::chars($newcode) - 1) eq "\\" {
                 # Need to get more code before we execute
-                $code := nqp::substr($code, 0, nqp::chars($code) - 1); # strip the \
+                # Strip the trailing \, but reinstate the newline 
+                $code := nqp::substr($code, 0, nqp::chars($code) - 1) ~ "\n";
                 if $code {
                     $prompt := '* ';
                 }


### PR DESCRIPTION
Say we want to define a class in our REPL, we might input:

    > class Foo {\
    * method foo {...}\
    * method bar {...}\
    }

Only to see

    ===SORRY!=== Error while compiling <unknown file>
    Strange text after block (missing semicolon or comma?)
    at <unknown file>:1
    ------> class Foo {method foo {...}⏏ method bar {...} }
        expecting any of:
            infix
            infix stopper
            postfix
            statement end
            statement modifier
            statement modifier loop

Which is surprising, and surprises are bad.

So, after we chomp the input in `deadline`, we unchomp it if we get a continuation, which means that the compiler sees code that looks like:

    class Foo {
    method foo {...}
    method bar {...}
    }

which is legal, rather than code like `class Foo { method foo {...}method bar {...}}`, which isn't. Everybody wins.