### PR TITLE
Speed up nqp::x by ~20% for large values of count on the JVM

### DIFF
--- a/src/vm/jvm/QAST/Compiler.nqp
+++ b/src/vm/jvm/QAST/Compiler.nqp
@@ -2264,7 +2264,7 @@ QAST::OperationsJAST.map_classlib_core_op('uc', $TYPE_OPS, 'uc', [$RT_STR], $RT_
 QAST::OperationsJAST.map_classlib_core_op('lc', $TYPE_OPS, 'lc', [$RT_STR], $RT_STR);
 QAST::OperationsJAST.map_classlib_core_op('tc', $TYPE_OPS, 'uc', [$RT_STR], $RT_STR);
 QAST::OperationsJAST.map_classlib_core_op('fc', $TYPE_OPS, 'lc', [$RT_STR], $RT_STR);
-QAST::OperationsJAST.map_classlib_core_op('x', $TYPE_OPS, 'x', [$RT_STR, $RT_INT], $RT_STR);
+QAST::OperationsJAST.map_classlib_core_op('x', $TYPE_OPS, 'x', [$RT_STR, $RT_INT], $RT_STR, :tc);
 QAST::OperationsJAST.map_classlib_core_op('iscclass', $TYPE_OPS, 'iscclass', [$RT_INT, $RT_STR, $RT_INT], $RT_INT);
 QAST::OperationsJAST.map_classlib_core_op('concat', $TYPE_OPS, 'concat', [$RT_STR, $RT_STR], $RT_STR);
 QAST::OperationsJAST.map_classlib_core_op('chr', $TYPE_OPS, 'chr', [$RT_INT], $RT_STR, :tc);

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
@@ -3910,8 +3910,11 @@ public final class Ops {
         return val.toUpperCase();
     }
 
-    public static String x(String val, long count) {
-        StringBuilder retval = new StringBuilder();
+    public static String x(String val, long count, ThreadContext tc) {
+        if (count < 0)
+            throw ExceptionHandling.dieInternal(tc, "repeat count (" + count + ") cannot be negative");
+
+        StringBuilder retval = new StringBuilder((int)Math.min(Integer.MAX_VALUE, val.length() * count));
         for (long ii = 1; ii <= count; ii++) {
             retval.append(val);
         }


### PR DESCRIPTION
Do this by setting the StringBuilder's initial capacity since we can calculate the expected value. Also throw an exception for negative values of count to match nqp-m's behavior.