### PR TITLE
Let nqp::rename replace existing target on JVM

### DIFF
--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
@@ -997,7 +997,7 @@ public final class Ops {
         Path before_o = Paths.get(before);
         Path after_o = Paths.get(after);
         try {
-            Files.move(before_o, after_o);
+            Files.move(before_o, after_o, StandardCopyOption.REPLACE_EXISTING);
         }
         catch (Exception e) {
             die_s(IOExceptionMessages.message(e), tc);


### PR DESCRIPTION
... unless it is a non-empty directory.

This matches the behaviour of nqp::rename on MoarVM
and it avoids errors during precompilation where an
older version should be replaced.