### PR TITLE
Correct type conversion for default arguments.

### DIFF
--- a/t/moar/04-argument-truncation.t
+++ b/t/moar/04-argument-truncation.t
@@ -1,0 +1,38 @@
+# t/moar/argument-truncation.t
+
+plan(8);
+
+sub pos8(int8  $i) {
+    ok($i==42, 'int8 pos argument works')
+}
+sub pos16(int16  $i) {
+    ok($i==42, 'int16 pos argument works')
+}
+sub pos32(int32  $i) {
+    ok($i==42, 'int32 pos argument works')
+}
+sub pos64(int64  $i) {
+    ok($i==42, 'int64 pos argument works')
+}
+pos8(42);
+pos16(42);
+pos32(42);
+pos64(42);
+
+sub named8(int8  :$i) {
+    ok($i==42, 'int8 named argument works')
+}
+sub named16(int16  :$i) {
+    ok($i==42, 'int16 named argument works')
+}
+sub named32(int32  :$i) {
+    ok($i==42, 'int32 named argument works')
+}
+sub named64(int64  :$i) {
+    ok($i==42, 'int64 named argument works')
+}
+named8(:i(42));
+named16(:i(42));
+named32(:i(42));
+named64(:i(42));
+


### PR DESCRIPTION
The code didn't take into account of the possible truncation of the
argument, we don't want to convert the default value to the type of the
register but rather to the type of the destination one.

This affects the MoarVM backend only.

Possible test vectors:
```perl6
class a { method m(int8  :$i) {$i}; }; say a.new().m(:i(42));
class a { method m(int16 :$i) {$i}; }; say a.new().m(:i(42));
class a { method m(int32 :$i) {$i}; }; say a.new().m(:i(42));
```