### PR TITLE
Simplify the compilation of 'if' switches.

### DIFF
--- a/src/vm/moar/QAST/QASTOperationsMAST.nqp
+++ b/src/vm/moar/QAST/QASTOperationsMAST.nqp
@@ -829,9 +829,11 @@ for <if unless with without> -> $op_name {
         $regalloc.release_register(@comp_ops[1].result_reg, @comp_ops[1].result_kind);
 
         # Handle else branch (coercion of condition result if 2-arg).
-        push_op(@ins, 'goto', $end_lbl);
-        nqp::push(@ins, $else_lbl);
         if $operands == 3 {
+            # Terminate the then branch first.
+            push_op(@ins, 'goto', $end_lbl);
+            nqp::push(@ins, $else_lbl);
+
             push_ilist(@ins, @comp_ops[2]);
             if !$is_void {
                 if @comp_ops[2].result_kind != $res_kind {
@@ -844,13 +846,6 @@ for <if unless with without> -> $op_name {
                 }
             }
             $regalloc.release_register(@comp_ops[2].result_reg, @comp_ops[2].result_kind);
-        }
-        else {
-            if !$is_void && @comp_ops[0].result_kind != $res_kind {
-                my $coercion := $qastcomp.coercion(@comp_ops[0], $res_kind);
-                push_ilist(@ins, $coercion);
-                push_op(@ins, 'set', $res_reg, $coercion.result_reg);
-            }
         }
         $regalloc.release_register(@comp_ops[0].result_reg, @comp_ops[0].result_kind);
         nqp::push(@ins, $end_lbl);


### PR DESCRIPTION
Optimize the case where there's no else branch by not emitting a goto.
Also, remove some other code that's being generated but is actually
unreachable.

The `then` branch is effectively terminated at [1], if `$operands` is 2 then we'll never reach the code generated into the following `if` as we directly jump to the `end_lbl`.

As a rough proof of correctness I've run both the NQP and the rakudo spectests with this modification and both gave positive results.

[1] https://github.com/perl6/nqp/blob/master/src/vm/moar/QAST/QASTOperationsMAST.nqp#L832