### PR TITLE
Properly numify non-ascii tokens in regex/grammars

### DIFF
--- a/src/QRegex/P6Regex/Actions.nqp
+++ b/src/QRegex/P6Regex/Actions.nqp
@@ -887,14 +887,26 @@ class QRegex::P6Regex::Actions is HLL::Actions {
             if $name eq '' { $name := $count; $ast.name($name); }
             my @names := nqp::split('=', $name);
             for @names {
-                if $_ eq '0' || $_ > 0 { $count := $_ + 1; }
-                %capnames{$_} := 1;
+                my $n := nqp::radix(10, $_, 0, 0)[0];
+                if $_ eq '0' || $n > 0 {
+                    $count := $n + 1;
+                    %capnames{$n} := 1
+                }
+                else {
+                    %capnames{$_} := 1;
+                }
             }
         }
         elsif $rxtype eq 'subcapture' {
             for nqp::split(' ', $ast.name) {
-                if $_ eq '0' || $_ > 0 { $count := $_ + 1; }
-                %capnames{$_} := 1;
+                my $n := nqp::radix(10, $_, 0, 0)[0];
+                if $_ eq '0' || $n > 0 {
+                    $count := $n + 1;
+                    %capnames{$n} := 1
+                }
+                else {
+                    %capnames{$_} := 1;
+                }
             }
             my %x := capnames($ast[0], $count);
             for %x { %capnames{$_.key} := +%capnames{$_.key} + %x{$_.key} }


### PR DESCRIPTION
Fix [RT #127075](https://rt.perl.org/Ticket/Display.html?id=127075)

Passes `make test` in nqp and `make spectest` in rakudo