### PR TITLE
Throw exception instead of calling dieInternal

### DIFF
--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
@@ -2386,8 +2386,6 @@ public final class Ops {
             ArgsExpectation.invokeByExpectation(tc, cr, csd, args);
         }
         catch (ControlException e) {
-            if (barrier && (e instanceof SaveStackException))
-                ExceptionHandling.dieInternal(tc, "control operator crossed continuation barrier");
             throw e;
         }
         catch (Throwable e) {


### PR DESCRIPTION
After removing this check for a SaveStackException
the special case for JVM in Rakudo's src/core/control.pm
is no longer needed.

There are no new failing tests (neither with 'make test'
for NQP nor with 'make test; make install; make spectest'
for Rakudo).

Fixes two tickets for rakudo-j:

* https://rt.perl.org/Ticket/Display.html?id=122732

* https://rt.perl.org/Ticket/Display.html?id=127967