### PR TITLE
Add four new pairs of matched delimiters brackets/parens

### DIFF
--- a/src/HLL/Grammar.nqp
+++ b/src/HLL/Grammar.nqp
@@ -1,7 +1,48 @@
 use QRegex;
 
 grammar HLL::Grammar {
-    my $brackets := "<>[]()\{}\x[0028]\x[0029]\x[003C]\x[003E]\x[005B]\x[005D]\x[007B]\x[007D]\x[00AB]\x[00BB]\x[0F3A]\x[0F3B]\x[0F3C]\x[0F3D]\x[169B]\x[169C]\x[2018]\x[2019]\x[201A]\x[2019]\x[201B]\x[2019]\x[201C]\x[201D]\x[201E]\x[201D]\x[201F]\x[201D]\x[2039]\x[203A]\x[2045]\x[2046]\x[207D]\x[207E]\x[208D]\x[208E]\x[2208]\x[220B]\x[2209]\x[220C]\x[220A]\x[220D]\x[2215]\x[29F5]\x[223C]\x[223D]\x[2243]\x[22CD]\x[2252]\x[2253]\x[2254]\x[2255]\x[2264]\x[2265]\x[2266]\x[2267]\x[2268]\x[2269]\x[226A]\x[226B]\x[226E]\x[226F]\x[2270]\x[2271]\x[2272]\x[2273]\x[2274]\x[2275]\x[2276]\x[2277]\x[2278]\x[2279]\x[227A]\x[227B]\x[227C]\x[227D]\x[227E]\x[227F]\x[2280]\x[2281]\x[2282]\x[2283]\x[2284]\x[2285]\x[2286]\x[2287]\x[2288]\x[2289]\x[228A]\x[228B]\x[228F]\x[2290]\x[2291]\x[2292]\x[2298]\x[29B8]\x[22A2]\x[22A3]\x[22A6]\x[2ADE]\x[22A8]\x[2AE4]\x[22A9]\x[2AE3]\x[22AB]\x[2AE5]\x[22B0]\x[22B1]\x[22B2]\x[22B3]\x[22B4]\x[22B5]\x[22B6]\x[22B7]\x[22C9]\x[22CA]\x[22CB]\x[22CC]\x[22D0]\x[22D1]\x[22D6]\x[22D7]\x[22D8]\x[22D9]\x[22DA]\x[22DB]\x[22DC]\x[22DD]\x[22DE]\x[22DF]\x[22E0]\x[22E1]\x[22E2]\x[22E3]\x[22E4]\x[22E5]\x[22E6]\x[22E7]\x[22E8]\x[22E9]\x[22EA]\x[22EB]\x[22EC]\x[22ED]\x[22F0]\x[22F1]\x[22F2]\x[22FA]\x[22F3]\x[22FB]\x[22F4]\x[22FC]\x[22F6]\x[22FD]\x[22F7]\x[22FE]\x[2308]\x[2309]\x[230A]\x[230B]\x[2329]\x[232A]\x[23B4]\x[23B5]\x[2768]\x[2769]\x[276A]\x[276B]\x[276C]\x[276D]\x[276E]\x[276F]\x[2770]\x[2771]\x[2772]\x[2773]\x[2774]\x[2775]\x[27C3]\x[27C4]\x[27C5]\x[27C6]\x[27D5]\x[27D6]\x[27DD]\x[27DE]\x[27E2]\x[27E3]\x[27E4]\x[27E5]\x[27E6]\x[27E7]\x[27E8]\x[27E9]\x[27EA]\x[27EB]\x[2983]\x[2984]\x[2985]\x[2986]\x[2987]\x[2988]\x[2989]\x[298A]\x[298B]\x[298C]\x[298D]\x[298E]\x[298F]\x[2990]\x[2991]\x[2992]\x[2993]\x[2994]\x[2995]\x[2996]\x[2997]\x[2998]\x[29C0]\x[29C1]\x[29C4]\x[29C5]\x[29CF]\x[29D0]\x[29D1]\x[29D2]\x[29D4]\x[29D5]\x[29D8]\x[29D9]\x[29DA]\x[29DB]\x[29F8]\x[29F9]\x[29FC]\x[29FD]\x[2A2B]\x[2A2C]\x[2A2D]\x[2A2E]\x[2A34]\x[2A35]\x[2A3C]\x[2A3D]\x[2A64]\x[2A65]\x[2A79]\x[2A7A]\x[2A7D]\x[2A7E]\x[2A7F]\x[2A80]\x[2A81]\x[2A82]\x[2A83]\x[2A84]\x[2A8B]\x[2A8C]\x[2A91]\x[2A92]\x[2A93]\x[2A94]\x[2A95]\x[2A96]\x[2A97]\x[2A98]\x[2A99]\x[2A9A]\x[2A9B]\x[2A9C]\x[2AA1]\x[2AA2]\x[2AA6]\x[2AA7]\x[2AA8]\x[2AA9]\x[2AAA]\x[2AAB]\x[2AAC]\x[2AAD]\x[2AAF]\x[2AB0]\x[2AB3]\x[2AB4]\x[2ABB]\x[2ABC]\x[2ABD]\x[2ABE]\x[2ABF]\x[2AC0]\x[2AC1]\x[2AC2]\x[2AC3]\x[2AC4]\x[2AC5]\x[2AC6]\x[2ACD]\x[2ACE]\x[2ACF]\x[2AD0]\x[2AD1]\x[2AD2]\x[2AD3]\x[2AD4]\x[2AD5]\x[2AD6]\x[2AEC]\x[2AED]\x[2AF7]\x[2AF8]\x[2AF9]\x[2AFA]\x[2E02]\x[2E03]\x[2E04]\x[2E05]\x[2E09]\x[2E0A]\x[2E0C]\x[2E0D]\x[2E1C]\x[2E1D]\x[2E20]\x[2E21]\x[2E28]\x[2E29]\x[3008]\x[3009]\x[300A]\x[300B]\x[300C]\x[300D]\x[300E]\x[300F]\x[3010]\x[3011]\x[3014]\x[3015]\x[3016]\x[3017]\x[3018]\x[3019]\x[301A]\x[301B]\x[301D]\x[301E]\x[FD3E]\x[FD3F]\x[FE17]\x[FE18]\x[FE35]\x[FE36]\x[FE37]\x[FE38]\x[FE39]\x[FE3A]\x[FE3B]\x[FE3C]\x[FE3D]\x[FE3E]\x[FE3F]\x[FE40]\x[FE41]\x[FE42]\x[FE43]\x[FE44]\x[FE47]\x[FE48]\x[FE59]\x[FE5A]\x[FE5B]\x[FE5C]\x[FE5D]\x[FE5E]\x[FF08]\x[FF09]\x[FF1C]\x[FF1E]\x[FF3B]\x[FF3D]\x[FF5B]\x[FF5D]\x[FF5F]\x[FF60]\x[FF62]\x[FF63]";
+    my $brackets := '<>[](){}'   ~  "\x[0028]\x[0029]\x[003C]\x[003E]\x[005B]\x[005D]" ~
+    "\x[007B]\x[007D]\x[00AB]\x[00BB]\x[0F3A]\x[0F3B]\x[0F3C]\x[0F3D]\x[169B]\x[169C]" ~
+    "\x[2018]\x[2019]\x[201A]\x[2019]\x[201B]\x[2019]\x[201C]\x[201D]\x[201E]\x[201D]" ~
+    "\x[201F]\x[201D]\x[2039]\x[203A]\x[2045]\x[2046]\x[207D]\x[207E]\x[208D]\x[208E]" ~
+    "\x[2208]\x[220B]\x[2209]\x[220C]\x[220A]\x[220D]\x[2215]\x[29F5]\x[223C]\x[223D]" ~
+    "\x[2243]\x[22CD]\x[2252]\x[2253]\x[2254]\x[2255]\x[2264]\x[2265]\x[2266]\x[2267]" ~
+    "\x[2268]\x[2269]\x[226A]\x[226B]\x[226E]\x[226F]\x[2270]\x[2271]\x[2272]\x[2273]" ~
+    "\x[2274]\x[2275]\x[2276]\x[2277]\x[2278]\x[2279]\x[227A]\x[227B]\x[227C]\x[227D]" ~
+    "\x[227E]\x[227F]\x[2280]\x[2281]\x[2282]\x[2283]\x[2284]\x[2285]\x[2286]\x[2287]" ~
+    "\x[2288]\x[2289]\x[228A]\x[228B]\x[228F]\x[2290]\x[2291]\x[2292]\x[2298]\x[29B8]" ~
+    "\x[22A2]\x[22A3]\x[22A6]\x[2ADE]\x[22A8]\x[2AE4]\x[22A9]\x[2AE3]\x[22AB]\x[2AE5]" ~
+    "\x[22B0]\x[22B1]\x[22B2]\x[22B3]\x[22B4]\x[22B5]\x[22B6]\x[22B7]\x[22C9]\x[22CA]" ~
+    "\x[22CB]\x[22CC]\x[22D0]\x[22D1]\x[22D6]\x[22D7]\x[22D8]\x[22D9]\x[22DA]\x[22DB]" ~
+    "\x[22DC]\x[22DD]\x[22DE]\x[22DF]\x[22E0]\x[22E1]\x[22E2]\x[22E3]\x[22E4]\x[22E5]" ~
+    "\x[22E6]\x[22E7]\x[22E8]\x[22E9]\x[22EA]\x[22EB]\x[22EC]\x[22ED]\x[22F0]\x[22F1]" ~
+    "\x[22F2]\x[22FA]\x[22F3]\x[22FB]\x[22F4]\x[22FC]\x[22F6]\x[22FD]\x[22F7]\x[22FE]" ~
+    "\x[2308]\x[2309]\x[230A]\x[230B]\x[2329]\x[232A]\x[23B4]\x[23B5]\x[2768]\x[2769]" ~
+    "\x[276A]\x[276B]\x[276C]\x[276D]\x[276E]\x[276F]\x[2770]\x[2771]\x[2772]\x[2773]" ~
+    "\x[2774]\x[2775]\x[27C3]\x[27C4]\x[27C5]\x[27C6]\x[27D5]\x[27D6]\x[27DD]\x[27DE]" ~
+    "\x[27E2]\x[27E3]\x[27E4]\x[27E5]\x[27E6]\x[27E7]\x[27E8]\x[27E9]\x[27EA]\x[27EB]" ~
+    "\x[2983]\x[2984]\x[2985]\x[2986]\x[2987]\x[2988]\x[2989]\x[298A]\x[298B]\x[298C]" ~
+    "\x[298D]\x[298E]\x[298F]\x[2990]\x[2991]\x[2992]\x[2993]\x[2994]\x[2995]\x[2996]" ~
+    "\x[2997]\x[2998]\x[29C0]\x[29C1]\x[29C4]\x[29C5]\x[29CF]\x[29D0]\x[29D1]\x[29D2]" ~
+    "\x[29D4]\x[29D5]\x[29D8]\x[29D9]\x[29DA]\x[29DB]\x[29F8]\x[29F9]\x[29FC]\x[29FD]" ~
+    "\x[2A2B]\x[2A2C]\x[2A2D]\x[2A2E]\x[2A34]\x[2A35]\x[2A3C]\x[2A3D]\x[2A64]\x[2A65]" ~
+    "\x[2A79]\x[2A7A]\x[2A7D]\x[2A7E]\x[2A7F]\x[2A80]\x[2A81]\x[2A82]\x[2A83]\x[2A84]" ~
+    "\x[2A8B]\x[2A8C]\x[2A91]\x[2A92]\x[2A93]\x[2A94]\x[2A95]\x[2A96]\x[2A97]\x[2A98]" ~
+    "\x[2A99]\x[2A9A]\x[2A9B]\x[2A9C]\x[2AA1]\x[2AA2]\x[2AA6]\x[2AA7]\x[2AA8]\x[2AA9]" ~
+    "\x[2AAA]\x[2AAB]\x[2AAC]\x[2AAD]\x[2AAF]\x[2AB0]\x[2AB3]\x[2AB4]\x[2ABB]\x[2ABC]" ~
+    "\x[2ABD]\x[2ABE]\x[2ABF]\x[2AC0]\x[2AC1]\x[2AC2]\x[2AC3]\x[2AC4]\x[2AC5]\x[2AC6]" ~
+    "\x[2ACD]\x[2ACE]\x[2ACF]\x[2AD0]\x[2AD1]\x[2AD2]\x[2AD3]\x[2AD4]\x[2AD5]\x[2AD6]" ~
+    "\x[2AEC]\x[2AED]\x[2AF7]\x[2AF8]\x[2AF9]\x[2AFA]\x[2E02]\x[2E03]\x[2E04]\x[2E05]" ~
+    "\x[2E09]\x[2E0A]\x[2E0C]\x[2E0D]\x[2E1C]\x[2E1D]\x[2E20]\x[2E21]\x[2E28]\x[2E29]" ~
+    "\x[3008]\x[3009]\x[300A]\x[300B]\x[300C]\x[300D]\x[300E]\x[300F]\x[3010]\x[3011]" ~
+    "\x[3014]\x[3015]\x[3016]\x[3017]\x[3018]\x[3019]\x[301A]\x[301B]\x[301D]\x[301E]" ~
+    "\x[FE17]\x[FE18]\x[FE35]\x[FE36]\x[FE37]\x[FE38]\x[FE39]\x[FE3A]\x[FE3B]\x[FE3C]" ~
+    "\x[FE3D]\x[FE3E]\x[FE3F]\x[FE40]\x[FE41]\x[FE42]\x[FE43]\x[FE44]\x[FE47]\x[FE48]" ~
+    "\x[FE59]\x[FE5A]\x[FE5B]\x[FE5C]\x[FE5D]\x[FE5E]\x[FF08]\x[FF09]\x[FF1C]\x[FF1E]" ~
+    "\x[FF3B]\x[FF3D]\x[FF5B]\x[FF5D]\x[FF5F]\x[FF60]\x[FF62]\x[FF63]\x[27EE]\x[27EF]" ~
+    "\x[2E24]\x[2E25]\x[27EC]\x[27ED]\x[2E22]\x[2E23]\x[2E26]\x[2E27]" ~
+    "\x[FD3E]\x[FD3F]"; # All brackets have matching Ps/Pe or Pi/Pf except \x[FD3E]\x[FD3F]
+                        # (ORNATE PARENTHESIS), which are allowed since they are RTL Text characters
 
     method perl() { self.HOW.name(self) ~ '.new() #`[' ~ nqp::where(self) ~ ']' }
 
@@ -120,7 +161,7 @@ grammar HLL::Grammar {
     token charnames { [<.ws><charname><.ws>]+ % ',' }
     token charspec {
         [
-        | '[' <charnames> ']' 
+        | '[' <charnames> ']'
         | \d+ [ _ \d+]*
         | <control=[ ?..Z ]>
         | <.panic: 'Unrecognized \\c character'>
@@ -131,7 +172,7 @@ grammar HLL::Grammar {
         ^^ '#' \s* 'line' \s+ $<line>=(\d+) [ \s+ $<filename>=(\S+) ]? $$
     }
 
-=begin 
+=begin
 
 =item O(*%spec)
 
@@ -183,7 +224,7 @@ of the match.
         @args.push('"');
         nqp::die(join('', @args))
     }
-    
+
     method FAILGOAL($goal, $dba?) {
         unless $dba {
             $dba := nqp::getcodename(nqp::callercode());
@@ -204,7 +245,7 @@ position C<pos>.
     method peek_delimiters(str $target, int $pos) {
         # peek at the next character
         my str $start := nqp::substr($target, $pos, 1);
-    
+
         # colon, word and whitespace characters aren't valid delimiters
         if $start eq ':' {
             self.panic('Colons may not be used to delimit quoting constructs');
@@ -340,7 +381,7 @@ An operator precedence parser.
         my str $inassoc;
         my int $more_infix;
         my int $term_done;
-        
+
         while 1 {
             nqp::bindattr_i($here, NQPCursor, '$!pos', $pos);
             $termcur := $here."$termishrx"();
@@ -352,14 +393,14 @@ An operator precedence parser.
             }
 
             $termish := $termcur.MATCH();
-            
+
             # Interleave any prefix/postfix we might have found.
             %termOPER := $termish;
             %termOPER := nqp::atkey(%termOPER, 'OPER')
                 while nqp::existskey(%termOPER, 'OPER');
             @prefixish  := nqp::atkey(%termOPER, 'prefixish');
             @postfixish := nqp::atkey(%termOPER, 'postfixish');
- 
+
             unless nqp::isnull(@prefixish) || nqp::isnull(@postfixish) {
                 while @prefixish && @postfixish {
                     my %preO     := @prefixish[0]<OPER><O>.made;
@@ -386,10 +427,10 @@ An operator precedence parser.
                 nqp::push(@opstack, nqp::shift(@prefixish)) while @prefixish;
                 nqp::push(@opstack, nqp::pop(@postfixish)) while @postfixish;
             }
-            nqp::deletekey($termish, 'prefixish');            
+            nqp::deletekey($termish, 'prefixish');
             nqp::deletekey($termish, 'postfixish');
             nqp::push(@termstack, nqp::atkey($termish, 'term'));
-        
+
             last if $noinfix;
 
             $more_infix := 1;
@@ -404,7 +445,7 @@ An operator precedence parser.
                     $term_done := 1;
                     last;
                 }
-        
+
                 # Next, try the infix itself.
                 nqp::bindattr_i($here, NQPCursor, '$!pos', $pos);
                 $infixcur := $here.infixish();
@@ -414,7 +455,7 @@ An operator precedence parser.
                     last;
                 }
                 $infix := $infixcur.MATCH();
-    
+
                 # We got an infix.
                 %inO := $infix<OPER><O>.made;
                 $termishrx := nqp::ifnull(nqp::atkey(%inO, 'nextterm'), 'termish');
@@ -443,7 +484,7 @@ An operator precedence parser.
                 }
             }
             last if $term_done;
-        
+
             # if equal precedence, use associativity to decide
             if $opprec eq $inprec {
                 $inassoc := nqp::atkey(%inO, 'assoc');
@@ -462,7 +503,7 @@ An operator precedence parser.
                     self.EXPR_nonlistassoc($infixcur, $op1, $op2) if $op1 ne $op2 && $op1 ne ':';
                 }
             }
-            
+
             nqp::push(@opstack, $infix); # The Shift
             nqp::bindattr_i($here, NQPCursor, '$!pos', $pos);
             $wscur := $here.ws();
@@ -470,7 +511,7 @@ An operator precedence parser.
             nqp::bindattr_i($here, NQPCursor, '$!pos', $pos);
             return $here if $pos < 0;
         }
-        
+
         self.EXPR_reduce(@termstack, @opstack) while @opstack;
         $pos := nqp::getattr_i($here, NQPCursor, '$!pos');
         $here := self.'!cursor_start_cur'();
@@ -481,9 +522,9 @@ An operator precedence parser.
         $here;
     }
 
-    method EXPR_reduce(@termstack, @opstack) { 
+    method EXPR_reduce(@termstack, @opstack) {
         my $op := nqp::pop(@opstack);
-        
+
         # Give it a fresh capture list, since we'll have assumed it has
         # no positional captures and not taken them.
         nqp::bindattr($op, NQPCapture, '@!array', nqp::list());
@@ -503,7 +544,7 @@ An operator precedence parser.
         elsif $opassoc eq 'list' {
             $sym := nqp::ifnull(nqp::atkey(%opOPER, 'sym'), '');
             nqp::unshift($op, nqp::pop(@termstack));
-            while @opstack {    
+            while @opstack {
                 last if $sym ne nqp::ifnull(
                     nqp::atkey(nqp::atkey(nqp::atpos(@opstack,
                         nqp::elems(@opstack) - 1), 'OPER'), 'sym'), '');
@@ -523,7 +564,7 @@ An operator precedence parser.
         self.'!reduce_with_match'('EXPR', $key, $op);
         nqp::push(@termstack, $op);
     }
-    
+
     method EXPR_nonassoc($cur, $op1, $op2) {
         $cur.panic('"' ~ $op1 ~ '" and "' ~ $op2 ~ '" are non-associative and require parens');
     }
@@ -553,7 +594,7 @@ An operator precedence parser.
             $cur
         }
     }
-    
+
     method MARKED(str $markname) {
         my %markhash := nqp::getattr(
             nqp::getattr(self, NQPCursor, '$!shared'),


### PR DESCRIPTION
These are the only four pairs in Unicode that we don't have
added.

Also add a comment saying that all open/close with Ps/Pe or Pi/Pf
except for the ornate parenthesis which open/close with the
opposite because they are RTL parens.

List of the four new pairs:
⟮ ⟯
Ps U+27EE MATHEMATICAL LEFT FLATTENED PARENTHESIS
Pe U+27EF MATHEMATICAL RIGHT FLATTENED PARENTHESIS
⸤ ⸥
Ps U+2E24 BOTTOM LEFT HALF BRACKET
Pe U+2E25 BOTTOM RIGHT HALF BRACKET
⟬ ⟭
Ps U+27EC MATHEMATICAL LEFT WHITE TORTOISE SHELL BRACKET
Pe U+27ED MATHEMATICAL RIGHT WHITE TORTOISE SHELL BRACKET
⸢ ⸣
Ps U+2E22 TOP LEFT HALF BRACKET
Pe U+2E23 TOP RIGHT HALF BRACKET
⸦ ⸧
Ps U+2E26 LEFT SIDEWAYS U BRACKET
Pe U+2E27 RIGHT SIDEWAYS U BRACKET