### PR TITLE
Handle Nd's as a backreference

### DIFF
--- a/src/QRegex/P5Regex/Actions.nqp
+++ b/src/QRegex/P5Regex/Actions.nqp
@@ -515,7 +515,7 @@ class QRegex::P5Regex::Actions is HLL::Actions {
 
     method metachar:sym<var>($/) {
         my $qast;
-        my $name := $<pos> ?? +$<pos> !! ~$<name>;
+        my $name := $<pos> ?? nqp::radix(10, $<pos>, 0, 0)[0] !! ~$<name>;
         if $<quantified_atom> {
             $qast := $<quantified_atom>[0].ast;
             if $qast.rxtype eq 'quant' && $qast[0].rxtype eq 'subrule' {

--- a/src/QRegex/P6Regex/Actions.nqp
+++ b/src/QRegex/P6Regex/Actions.nqp
@@ -289,7 +289,7 @@ class QRegex::P6Regex::Actions is HLL::Actions {
 
     method metachar:sym<var>($/) {
         my $qast;
-        my $name := $<pos> ?? +$<pos> !! ~$<name>;
+        my $name := $<pos> ?? nqp::radix(10, $<pos>, 0, 0)[0] !! ~$<name>;
         if $<quantified_atom> {
             $qast := $<quantified_atom>[0].ast;
             if ($qast.rxtype eq 'quant' || $qast.rxtype eq 'dynquant') && $qast[0].rxtype eq 'subrule' {


### PR DESCRIPTION
So perl6 -e 'say "abca" ~~ /(a)(b)(c)$٠/' now matches.

Passes `make m-test`, also a Rakudo built with this passes `make m-spectest`.