### PR TITLE
Handle Nd's as regex quantifiers

### DIFF
--- a/src/QRegex/P5Regex/Actions.nqp
+++ b/src/QRegex/P5Regex/Actions.nqp
@@ -344,8 +344,8 @@ class QRegex::P5Regex::Actions is HLL::Actions {
     
     method p5quantifier:sym<{ }>($/) {
         my $qast;
-        $qast := QAST::Regex.new( :rxtype<quant>, :min(+$<start>), :node($/) );
-        if $<end> && ~$<end>[0] ne '' { $qast.max(+$<end>[0]); }
+        $qast := QAST::Regex.new( :rxtype<quant>, :min(nqp::radix(10, $<start>, 0, 0)[0]), :node($/) );
+        if $<end> && ~$<end>[0] ne '' { $qast.max(nqp::radix(10, $<end>[0], 0, 0)[0]); }
         elsif $<comma>                { $qast.max(-1); }
         else                          { $qast.max($qast.min); }
         make quantmod($qast, $<quantmod>);

--- a/src/QRegex/P6Regex/Actions.nqp
+++ b/src/QRegex/P6Regex/Actions.nqp
@@ -169,7 +169,7 @@ class QRegex::P6Regex::Actions is HLL::Actions {
         }
         else {
             my $min := 0;
-            if $<min> { $min := $<min>.ast; }
+            if $<min> { $min := nqp::radix(10, $<min>, 0, 0)[0]; }
 
             my $max := -1;
             my $upto := $<upto>;
@@ -180,7 +180,7 @@ class QRegex::P6Regex::Actions is HLL::Actions {
                 $max := $min
             }
             elsif $<max> ne '*' {
-                $max := $<max>.ast;
+                $max := nqp::radix(10, $<max>, 0, 0)[0];
                 if $<upto> eq '^' {
                     $max--;
                 }

--- a/src/QRegex/P6Regex/Grammar.nqp
+++ b/src/QRegex/P6Regex/Grammar.nqp
@@ -273,14 +273,14 @@ grammar QRegex::P6Regex::Grammar is HLL::Grammar {
               ]
               [
               | $<upto>='^'? <max=.integer> {
-                  $/.CURSOR.panic("Negative numbers are not allowed as quantifiers") if $<max>.Str < 0;
+                  $/.CURSOR.panic("Negative numbers are not allowed as quantifiers") if nqp::radix(10, $<max>, 0, 0)[0] < 0;
                 }
               | $<max>=['*']
               | <.throw_malformed_range>
               ]
             ]?
           ]
-          { $/.CURSOR.panic("Negative numbers are not allowed as quantifiers") if $<min>.Str < 0 }
+          { $/.CURSOR.panic("Negative numbers are not allowed as quantifiers") if nqp::radix(10, $<min>, 0, 0)[0] < 0 }
         | <?[{]> <codeblock>
         ]
     }


### PR DESCRIPTION
Passes `make m-test` and a Rakudo built with it passes `make m-spectest`.