### PR TITLE
Micro-optimize Grammars

### DIFF
--- a/src/HLL/Grammar.nqp
+++ b/src/HLL/Grammar.nqp
@@ -156,7 +156,7 @@ grammar HLL::Grammar {
 
     token charname {
         || <integer>
-        || <.alpha> .*? <?before \s* <[ \] , # ]> >
+        || <.alpha> .*? <?before \s* <.[ \] , # ]> >
     }
     token charnames { [<.ws><charname><.ws>]+ % ',' }
     token charspec {

--- a/src/NQP/Grammar.nqp
+++ b/src/NQP/Grammar.nqp
@@ -146,7 +146,7 @@ grammar NQP::Grammar is HLL::Grammar {
         ''
         [
         | $
-        | <?before <[\)\]\}]>>
+        | <?before <.[\)\]\}]>>
         | [ <statement> <.eat_terminator> ]*
         ]
     }
@@ -162,7 +162,7 @@ grammar NQP::Grammar is HLL::Grammar {
     }
 
     token statement($*LABEL = '') {
-        <!before <[\])}]> | $ >
+        <!before <.[\])}]> | $ >
         [
         | <label> <statement($*LABEL)> { $*LABEL := '' if $*LABEL }
         | <statement_control>
@@ -828,7 +828,7 @@ grammar NQP::Regex is QRegex::P6Regex::Grammar {
     }
 
     token metachar:sym<nqpvar> {
-        <?before <sigil> [\W\w | \w]> <var=.LANG('MAIN', 'variable')> <.SIGOK>
+        <?before <.sigil> [\W\w | \w]> <var=.LANG('MAIN', 'variable')> <.SIGOK>
     }
 
     token assertion:sym<{ }> {

--- a/src/QRegex/P5Regex/Grammar.nqp
+++ b/src/QRegex/P5Regex/Grammar.nqp
@@ -72,7 +72,7 @@ grammar QRegex::P5Regex::Grammar is HLL::Grammar {
         <![|)]>
         <!rxstopper>
         <atom>
-        [ <.ws> <!before <rxstopper> > <quantifier=p5quantifier> ]**0..1
+        [ <.ws> <!before <.rxstopper> > <quantifier=p5quantifier> ]**0..1
         <.ws>
     }
     

--- a/src/QRegex/P6Regex/Grammar.nqp
+++ b/src/QRegex/P6Regex/Grammar.nqp
@@ -153,8 +153,8 @@ grammar QRegex::P6Regex::Grammar is HLL::Grammar {
     regex infixstopper {
         :dba('infix stopper')
         [
-        | <?before <[\) \} \]]> >
-        | <?before '>' <-[>]> >
+        | <?before <.[\) \} \]]> >
+        | <?before '>' <.-[>]> >
         | <?rxstopper>
         ]
     }
@@ -192,8 +192,8 @@ grammar QRegex::P6Regex::Grammar is HLL::Grammar {
         :my $*VARDEF := 0;
         [
         || <noun=.quantified_atom>+
-        || <?before <rxstopper> | <[&|~]> > <.throw_null_pattern>
-        || <?before <infixstopper> > <.throw_null_pattern> # XXX Check if unmatched bracket
+        || <?before <.rxstopper> | <.[&|~]> > <.throw_null_pattern>
+        || <?before <.infixstopper> > <.throw_null_pattern> # XXX Check if unmatched bracket
         || $$ <.throw_regex_not_terminated>
         || (\W) { self.throw_unrecognized_metachar: ~$/[0] }
         || <.throw_regex_not_terminated>


### PR DESCRIPTION
Make  `<before>`'s non-capturing.

Passes `make m-test` and a Rakudo built with it passes `make m-spectest`.