### PR TITLE
Use nqp::findmethod instead of *.HOW.find_method

### DIFF
--- a/src/QRegex/NFA.nqp
+++ b/src/QRegex/NFA.nqp
@@ -533,7 +533,9 @@ class QRegex::NFA {
             nqp::printfh($err,"$indent mergesubrule $name start $start to $to fate $fate\n") if $nfadeb;
             $n := $name;
             if !nqp::existskey(%seen, $name) {
-                $meth := $cursor.HOW.find_method($cursor, $name, :no_trace(1));
+                $meth := nqp::can($cursor.HOW, 'traced') && $cursor.HOW.traced($cursor)
+                    ?? $cursor.HOW.find_method($cursor, $name, :no_trace(1))
+                    !! nqp::findmethod($cursor, $name);
                 if nqp::can($meth, 'NFA') {
                     @substates := $meth.NFA();
                     @substates := [] if nqp::isnull(@substates);


### PR DESCRIPTION
If the meta-object is not being traced we can use the much faster NQP
op. This reduces the time needed to compile a script that just defines
50 custom operators from ~60s to ~40s.

Passes `make m-test` and a Rakudo built with it passes `make m-spectest`.

jnthn++, timotimo++, lizmat++