### PR TITLE
Intify things that cause the most mvm coerce smart numify

### DIFF
--- a/src/core/NQPMu.nqp
+++ b/src/core/NQPMu.nqp
@@ -12,8 +12,8 @@ my class NQPMu {
     method BUILDALL(NQPMu:D $self: *%attrinit) {
         # Get the build plan.
         my $build_plan := self.HOW.BUILDALLPLAN(self);
-        my $count      := nqp::elems($build_plan);
-        my $i          := 0;
+        my int $count  := nqp::elems($build_plan);
+        my int $i      := 0;
         while $i < $count {
             my $task := nqp::atpos($build_plan, $i);
             my int $code := nqp::atpos($task, 0);

--- a/src/core/NQPRoutine.nqp
+++ b/src/core/NQPRoutine.nqp
@@ -51,18 +51,18 @@ my knowhow NQPRoutine {
     
     # Sorts the dispatchees. Puts nulls between groups that are of equal weight.
     # The most specific group comes first.
-    my $SLURPY_ARITY      := nqp::bitshiftl_i(1, 30);
-    my $EDGE_REMOVAL_TODO := -1;
-    my $EDGE_REMOVED      := -2;
-    my $DEFINED_ONLY      := 1;
-    my $UNDEFINED_ONLY    := 2;
+    my int $SLURPY_ARITY      := nqp::bitshiftl_i(1, 30);
+    my int $EDGE_REMOVAL_TODO := -1;
+    my int $EDGE_REMOVED      := -2;
+    my int $DEFINED_ONLY      := 1;
+    my int $UNDEFINED_ONLY    := 2;
     method sort_dispatchees() {        
         # Takes two candidates and determines if the first one is narrower than the
         # second. Returns a true value if they are.
         sub is_narrower(%a, %b) {
             # Work out how many parameters to compare, factoring in slurpiness
             # and optionals.
-            my $types_to_check;
+            my int $types_to_check;
             if %a<num_types> == %b<num_types> {
                 $types_to_check := %a<num_types>;
             }
@@ -117,7 +117,7 @@ my knowhow NQPRoutine {
             my $multi_sig := $candidate.signature;
             my @types_list := $multi_sig.types;
             my @definedness_list := $multi_sig.definednesses;
-            my $sig_elems := nqp::elems(@types_list);
+            my int $sig_elems := nqp::elems(@types_list);
 
             # Type information.
             my %info := nqp::hash(
@@ -174,9 +174,9 @@ my knowhow NQPRoutine {
 
         # Perform the topological sort.
         my @result;
-        my $candidates_to_sort := $num_candidates;
+        my int $candidates_to_sort := $num_candidates;
         while $candidates_to_sort > 0 {
-            my $rem_results := nqp::elems(@result);
+            my int $rem_results := nqp::elems(@result);
 
             # Find any nodes that have no incoming edges and add them to
             # results.
@@ -199,7 +199,7 @@ my knowhow NQPRoutine {
             $i := 0;
             while $i < $num_candidates {
                 if @graph[$i]<edges_in> == $EDGE_REMOVAL_TODO {
-                    my $j := 0;
+                    my int $j := 0;
                     while $j < @graph[$i]<edges_out> {
                         @graph[$i]<edges>[$j]<edges_in>--;
                         $j++;
@@ -221,7 +221,7 @@ my knowhow NQPRoutine {
     
     method dispatch($capture) {
         # Count arguments.
-        my $num_args := nqp::captureposelems($capture);
+        my int $num_args := nqp::captureposelems($capture);
 
         # Get list and number of candidates, triggering a sort if there are none.
         my @candidates := $!dispatch_order;
@@ -230,7 +230,7 @@ my knowhow NQPRoutine {
             @candidates := $!dispatch_order := self.sort_dispatchees();
             nqp::scwbenable();
         }
-        my $num_candidates := nqp::elems(@candidates);
+        my int $num_candidates := nqp::elems(@candidates);
 
         # Initialize dispatcher state.
         my @possibles;
@@ -283,7 +283,7 @@ my knowhow NQPRoutine {
                 }
                 if $definedness {
                     # Have a constraint on the definedness.
-                    my $defined := nqp::isnull($param_type) ?? nqp::defined($param) !! nqp::isconcrete($param);
+                    my int $defined := nqp::isnull($param_type) ?? nqp::defined($param) !! nqp::isconcrete($param);
                     if (!$defined && $definedness == $DEFINED_ONLY) || ($defined && $definedness == $UNDEFINED_ONLY) {
                         $type_mismatch := 1;
                         last;

--- a/src/vm/moar/NQP/Ops.nqp
+++ b/src/vm/moar/NQP/Ops.nqp
@@ -1,8 +1,8 @@
 my $ops := QAST::MASTCompiler.operations();
-my $MVM_reg_int64           := 4;
-my $MVM_reg_num64           := 6;
-my $MVM_reg_str             := 7;
-my $MVM_reg_obj             := 8;
+my int $MVM_reg_int64           := 4;
+my int $MVM_reg_num64           := 6;
+my int $MVM_reg_str             := 7;
+my int $MVM_reg_obj             := 8;
 
 $ops.add_hll_op('nqp', 'preinc', -> $qastcomp, $op {
     my $var := $op[0];

--- a/src/vm/moar/QAST/QASTCompilerMAST.nqp
+++ b/src/vm/moar/QAST/QASTCompilerMAST.nqp
@@ -103,7 +103,7 @@ my class MASTCompilerInstance {
         method release_s($reg) { self.release_register($reg, $MVM_reg_str) }
         method release_o($reg) { self.release_register($reg, $MVM_reg_obj) }
 
-        method release_register($reg, $kind, $force = 0) {
+        method release_register($reg, int $kind, int $force = 0) {
             return 1 if $kind == $MVM_reg_void || !$force && $*BLOCK.is_var($reg)
                 || nqp::existskey(%!released_indexes, $reg.index);
             %!released_indexes{$reg.index} := 1;

--- a/src/vm/moar/QAST/QASTOperationsMAST.nqp
+++ b/src/vm/moar/QAST/QASTOperationsMAST.nqp
@@ -1,28 +1,28 @@
-my $MVM_operand_literal     := 0;
-my $MVM_operand_read_reg    := 1;
-my $MVM_operand_write_reg   := 2;
-my $MVM_operand_read_lex    := 3;
-my $MVM_operand_write_lex   := 4;
-my $MVM_operand_rw_mask     := 7;
+my int $MVM_operand_literal     := 0;
+my int $MVM_operand_read_reg    := 1;
+my int $MVM_operand_write_reg   := 2;
+my int $MVM_operand_read_lex    := 3;
+my int $MVM_operand_write_lex   := 4;
+my int $MVM_operand_rw_mask     := 7;
 
-my $MVM_operand_int8        := ($MVM_reg_int8 * 8);
-my $MVM_operand_int16       := ($MVM_reg_int16 * 8);
-my $MVM_operand_int32       := ($MVM_reg_int32 * 8);
-my $MVM_operand_int64       := ($MVM_reg_int64 * 8);
-my $MVM_operand_num32       := ($MVM_reg_num32 * 8);
-my $MVM_operand_num64       := ($MVM_reg_num64 * 8);
-my $MVM_operand_str         := ($MVM_reg_str * 8);
-my $MVM_operand_obj         := ($MVM_reg_obj * 8);
-my $MVM_operand_ins         := (9 * 8);
-my $MVM_operand_type_var    := (10 * 8);
-my $MVM_operand_lex_outer   := (11 * 8);
-my $MVM_operand_coderef     := (12 * 8);
-my $MVM_operand_callsite    := (13 * 8);
-my $MVM_operand_type_mask   := (31 * 8);
-my $MVM_operand_uint8       := ($MVM_reg_uint8 * 8);
-my $MVM_operand_uint16      := ($MVM_reg_uint16 * 8);
-my $MVM_operand_uint32      := ($MVM_reg_uint32 * 8);
-my $MVM_operand_uint64      := ($MVM_reg_uint64 * 8);
+my int $MVM_operand_int8        := ($MVM_reg_int8 * 8);
+my int $MVM_operand_int16       := ($MVM_reg_int16 * 8);
+my int $MVM_operand_int32       := ($MVM_reg_int32 * 8);
+my int $MVM_operand_int64       := ($MVM_reg_int64 * 8);
+my int $MVM_operand_num32       := ($MVM_reg_num32 * 8);
+my int $MVM_operand_num64       := ($MVM_reg_num64 * 8);
+my int $MVM_operand_str         := ($MVM_reg_str * 8);
+my int $MVM_operand_obj         := ($MVM_reg_obj * 8);
+my int $MVM_operand_ins         := (9 * 8);
+my int $MVM_operand_type_var    := (10 * 8);
+my int $MVM_operand_lex_outer   := (11 * 8);
+my int $MVM_operand_coderef     := (12 * 8);
+my int $MVM_operand_callsite    := (13 * 8);
+my int $MVM_operand_type_mask   := (31 * 8);
+my int $MVM_operand_uint8       := ($MVM_reg_uint8 * 8);
+my int $MVM_operand_uint16      := ($MVM_reg_uint16 * 8);
+my int $MVM_operand_uint32      := ($MVM_reg_uint32 * 8);
+my int $MVM_operand_uint64      := ($MVM_reg_uint64 * 8);
 
 # This is used as a return value from all of the various compilation routines.
 # It groups together a set of instructions along with a result register and a
@@ -310,7 +310,7 @@ class QAST::MASTOperations {
         self.set_hll_op_result_type($hll, $op, moarop_return_type($moarop));
     }
 
-    method check_ret_val(str $moarop, $ret) {
+    method check_ret_val(str $moarop, int $ret) {
         my int $num_operands;
         my int $operands_offset;
         my @operands_values;
@@ -338,7 +338,7 @@ class QAST::MASTOperations {
     # Returns a mapper closure for turning an operation into a Moar op.
     # $ret is the 0-based index of which arg to use as the result when
     # the moarop is void.
-    method moarop_mapper(str $moarop, $ret, $decont_in) {
+    method moarop_mapper(str $moarop, int $ret, $decont_in) {
         # do a little checking of input values
 
         my $self := self;
@@ -389,7 +389,7 @@ class QAST::MASTOperations {
     }
 
     # Sets op native result type at a core level.
-    method set_core_op_result_type(str $op, $type) {
+    method set_core_op_result_type(str $op, int $type) {
         if $type == $MVM_reg_int64 {
             %core_result_type{$op} := int;
         }
@@ -403,7 +403,7 @@ class QAST::MASTOperations {
 
     # Sets op inlinability at a HLL level. (Can override at HLL level whether
     # or not the HLL overrides the op itself.)
-    method set_hll_op_result_type(str $hll, str $op, $type) {
+    method set_hll_op_result_type(str $hll, str $op, int $type) {
         %hll_result_type{$hll} := {} unless nqp::existskey(%hll_result_type, $hll);
         if $type == $MVM_reg_int64 {
             %hll_result_type{$hll}{$op} := int;
@@ -431,7 +431,7 @@ class QAST::MASTOperations {
     }
 
     # Adds a HLL box handler.
-    method add_hll_box(str $hll, $type, $handler) {
+    method add_hll_box(str $hll, int $type, $handler) {
         unless $type == $MVM_reg_int64 || $type == $MVM_reg_num64 || $type == $MVM_reg_str ||
                 $type == $MVM_reg_uint64 || $type == $MVM_reg_void {
             nqp::die("Unknown box type '$type'");
@@ -441,7 +441,7 @@ class QAST::MASTOperations {
     }
 
     # Adds a HLL unbox handler.
-    method add_hll_unbox(str $hll, $type, $handler) {
+    method add_hll_unbox(str $hll, int $type, $handler) {
         unless $type == $MVM_reg_int64 || $type == $MVM_reg_num64 ||
                 $type == $MVM_reg_str || $type == $MVM_reg_uint64 {
             nqp::die("Unknown unbox type '$type'");

--- a/src/vm/moar/QAST/QASTOperationsMAST.nqp
+++ b/src/vm/moar/QAST/QASTOperationsMAST.nqp
@@ -152,12 +152,12 @@ class QAST::MASTOperations {
             $*BLOCK.return_kind($MVM_reg_void);
         }
 
-        my $arg_num := 0;
+        my int $arg_num := 0;
         # Compile provided args.
         for @args {
-            my $operand := nqp::atpos_i(@operands_values, $operands_offset + $operand_num++);
+            my int $operand := nqp::atpos_i(@operands_values, $operands_offset + $operand_num++);
             my int $operand_kind := ($operand +& $MVM_operand_type_mask);
-            my $constant_operand := !($operand +& $MVM_operand_rw_mask);
+            my int $constant_operand := !($operand +& $MVM_operand_rw_mask);
             my $arg := $operand_kind == $MVM_operand_type_var
                 ?? $qastcomp.as_mast($_)
                 !! $qastcomp.as_mast($_, :want($operand_kind/8));

--- a/src/vm/moar/QAST/QASTOperationsMAST.nqp
+++ b/src/vm/moar/QAST/QASTOperationsMAST.nqp
@@ -119,12 +119,12 @@ class QAST::MASTOperations {
             nqp::die("MoarVM op '$op' is unknown as a core or extension op");
         }
 
-        my $num_args := +@args;
-        my $operand_num := 0;
-        my $result_kind := $MVM_reg_void;
+        my int $num_args := +@args;
+        my int $operand_num := 0;
+        my int $result_kind := $MVM_reg_void;
         my $result_reg := MAST::VOID;
-        my $needs_write := 0;
-        my $type_var_kind := 0;
+        my int $needs_write := 0;
+        my int $type_var_kind := 0;
         my $regalloc := $*REGALLOC;
 
         my @arg_regs;
@@ -156,12 +156,12 @@ class QAST::MASTOperations {
         # Compile provided args.
         for @args {
             my $operand := nqp::atpos_i(@operands_values, $operands_offset + $operand_num++);
-            my $operand_kind := ($operand +& $MVM_operand_type_mask);
+            my int $operand_kind := ($operand +& $MVM_operand_type_mask);
             my $constant_operand := !($operand +& $MVM_operand_rw_mask);
             my $arg := $operand_kind == $MVM_operand_type_var
                 ?? $qastcomp.as_mast($_)
                 !! $qastcomp.as_mast($_, :want($operand_kind/8));
-            my $arg_kind := $arg.result_kind;
+            my int $arg_kind := $arg.result_kind;
 
             if $arg_num == 0 && nqp::substr($op, 0, 7) eq 'return_' {
                 $*BLOCK.return_kind($arg.result_kind);
@@ -229,7 +229,7 @@ class QAST::MASTOperations {
         }
 
         # release the registers to the allocator. See comment there.
-        my $release_i := 0;
+        my int $release_i := 0;
         $regalloc.release_register($_, @release_kinds[$release_i++]) for @release_regs;
 
         # unshift in a generated write register arg if it needs one

--- a/src/vm/moar/QAST/QASTRegexCompilerMAST.nqp
+++ b/src/vm/moar/QAST/QASTRegexCompilerMAST.nqp
@@ -4,19 +4,19 @@ use MASTNodes;
 use MASTOps;
 use QRegex;
 
-my $MVM_reg_void            := 0; # not really a register; just a result/return kind marker
-my $MVM_reg_int8            := 1;
-my $MVM_reg_int16           := 2;
-my $MVM_reg_int32           := 3;
-my $MVM_reg_int64           := 4;
-my $MVM_reg_num32           := 5;
-my $MVM_reg_num64           := 6;
-my $MVM_reg_str             := 7;
-my $MVM_reg_obj             := 8;
-my $MVM_reg_uint8           := 17;
-my $MVM_reg_uint16          := 18;
-my $MVM_reg_uint32          := 19;
-my $MVM_reg_uint64          := 20;
+my int $MVM_reg_void            := 0; # not really a register; just a result/return kind marker
+my int $MVM_reg_int8            := 1;
+my int $MVM_reg_int16           := 2;
+my int $MVM_reg_int32           := 3;
+my int $MVM_reg_int64           := 4;
+my int $MVM_reg_num32           := 5;
+my int $MVM_reg_num64           := 6;
+my int $MVM_reg_str             := 7;
+my int $MVM_reg_obj             := 8;
+my int $MVM_reg_uint8           := 17;
+my int $MVM_reg_uint16          := 18;
+my int $MVM_reg_uint32          := 19;
+my int $MVM_reg_uint64          := 20;
 
 class QAST::MASTRegexCompiler {
     # The compiler we're working against.


### PR DESCRIPTION
Passes `make m-test` and a Rakudo built with it passes `make m-spectest`.

There's no reason for these to be separate commits when merged, they can be squashed.