### PR TITLE
Update qregex tests to allow backend specific todo's

### DIFF
--- a/t/qregex/01-qregex.t
+++ b/t/qregex/01-qregex.t
@@ -3,6 +3,9 @@
 # for string_to_int
 use QRegex;
 
+my %backendconfig := nqp::backendconfig();
+my $vm := nqp::existskey(%backendconfig, 'moar') ?? 'moar' !!
+          nqp::existskey(%backendconfig, 'runtime.jars') ?? 'jvm' !! '';
 my @files := [
     'rx_captures',
     'rx_qcaps',
@@ -81,9 +84,10 @@ for @files -> $fn {
         !! nqp::split("\n", $contents);
 
     for @lines -> $l {
-        my $m := $l ~~ /'# todo ' .*? ':pge<' (.*?) '>'/;
+        my $m := $l ~~ / ^ '# todo ' .*? ':' (\S+) '<' (.*) '>'/;
+        #$m := $l ~~ /'#?' (\S+) 
         if $m {
-            todo($m[0], 1);
+            todo($m[1], 1) if $m[0] eq $vm || $m[0] eq 'any';
         }
         else {
             next if $l ~~ /^ \s* '#' | ^ \s* $ /;

--- a/t/qregex/01-qregex.t
+++ b/t/qregex/01-qregex.t
@@ -84,10 +84,10 @@ for @files -> $fn {
         !! nqp::split("\n", $contents);
 
     for @lines -> $l {
-        my $m := $l ~~ / ^ '# todo ' .*? ':' (\S+) '<' (.*) '>'/;
-        #$m := $l ~~ /'#?' (\S+) 
+        my $m := $l ~~ / ^ '# todo ' .*? (\d+)? .*? ':' (\S+) '<' (.*) '>'/;
         if $m {
-            todo($m[1], 1) if $m[0] eq $vm || $m[0] eq 'any';
+            my $to-todo := $m[0] ?? nqp::radix(10, $m[0], 0, 0)[0] !! 1;
+            todo($m[2], $to-todo) if $m[1] eq $vm || $m[1] eq 'any';
         }
         else {
             next if $l ~~ /^ \s* '#' | ^ \s* $ /;

--- a/t/qregex/rx_backtrack
+++ b/t/qregex/rx_backtrack
@@ -7,29 +7,29 @@ a*: a			bazaar		n	basic
 \d+:			123abc		y	cut on character class shortcut
 \d+:			abc		n	cut on character class shortcut
 [ if    not | ify ]	verify		y	control
-# todo :pge<::>
+# todo :any<::>
 [ if :: not | ify ]	verify		n	inside a group
-# todo :pge<::>
+# todo :any<::>
   if :: not | ify	verify		n	the default all group
 [ if :  not | ify ]	verify		y	simple backtrack still works
-# todo :pge<::>
+# todo :any<::>
 [ if :: not | ify ] | verify	verify	y	rule continues
 [ when     ever ] | whence	whence	y	full backtrack failure
-# todo :pge<::>
+# todo :any<::>
 [ when ::: ever ] | whence	whence	n	full backtrack failure
-# todo :pge<::>
+# todo :any<::>
 ab::cd | gh::ij		xyabghij	y	group cut at top
-# todo :pge<::>
+# todo :any<::>
 ab:::cd | gh:::ij	xyabghij	n	rule cut at top
-# todo :pge<::>
+# todo :any<::>
 [ab::cd | gh::ij]	xyabghij	y	group cut in group
-# todo :pge<::>
+# todo :any<::>
 [ab:::cd | gh:::ij]	xyabghij	n	rule cut in group
-# todo :pge<:>
+# todo :any<:>
 [ ab | abc ]: de	xyzabcde	n	no backtrack into group
-# todo :pge<:>
+# todo :any<:>
 ( ab | abc ): de	xyzabcde	n	no backtrack into subpattern
-# todo :pge<:>
+# todo :any<:>
 [ when <commit> ever ] | whence	whence	n	full backtrack failure
 
 :ratchet a* a		bazaar		n	ratchet modifier

--- a/t/qregex/rx_charclass
+++ b/t/qregex/rx_charclass
@@ -22,7 +22,7 @@
 # todo :pugs<feature>
 <- [b..d]>		abcdef		y	negated allows ws
 <-[b..d]>		bbccdd		n	negated character range
-# todo :pge<reversed character range>
+# todo :any<reversed character range>
 <-[d..b]>		bbccdd		/parse error/	illegal character range
 <[x-z]>			ab-def		<Unsupported>	perl5 range
 <[-]>			ab-def		y	unescaped hyphen, the only thing
@@ -47,7 +47,7 @@
 <-[+\-]>		------		n	negated escaped hyphen in range
 <["\\]>			\\			y	escaped backslash
 <[\]]>			]			y	escaped close bracket
-# todo :pge<backslash escapes in char classes>
+# todo :any<backslash escapes in char classes>
 <[\]>			\\]]		/error/	unescaped backslash (or no closing brace)
 ^\><[<]>		><		y	lt character class
 ^<[>]>\<		><		y	gt character class
@@ -75,9 +75,11 @@
 "ab<'>cd"		ab<'>cd		y	literal match with quote
 # todo :pugs<feature>
 "ab\\cd"		ab\x005ccd	y	literal match with backslash
-# todo :pugs<feature> :pge<feature>
+# todo :pugs<feature>
+# todo :any<feature>
 (ab)x"$0"		abxab		y	literal match with interpolation
-# todo :pugs<feature> :pge<feature>
+# todo :pugs<feature>
+# todo :any<feature>
 (ab)"x$0"		abxab		y	literal match with interpolation
 '?'			ab<?		y	literal match with question mark
 '<'			ab<?		y	literal match with lt

--- a/t/qregex/rx_metachars
+++ b/t/qregex/rx_metachars
@@ -89,13 +89,13 @@ $$ \n			\n		y	line beginnings and endings ($$)
 ^ [ <[a..d]>+ | <[b..e]>+ ] $	bcd		y	alternation (|)
 ^ [ <[a..c]>+ | <[b..e]>+ ] $	bcd		y	alternation (|)
 ^ [ <[a..d]>+ | <[c..e]>+ ] $	bcd		y	alternation (|)
-# todo :pge<feature>
+# todo :any<feature>
 b|			bcd		<Null pattern>	alternation (|) - null right arg illegal
 |b			bcd		y	alternation (|) - null left arg ignored
-# todo :pge<feature>
+# todo :any<feature>
 |			bcd		<Null pattern>	alternation (|) - null both args illegal
 \|			|		y	alternation (|) - literal must be escaped
-# todo :pge<feature>
+# todo :any<feature>
 |			|		<Null pattern>	alternation (|) - literal must be escaped
 # todo :pugs<feature>
 <[a..d]> && <[b..e]>	c		y	conjunction (&&)
@@ -110,26 +110,27 @@ b|			bcd		<Null pattern>	alternation (|) - null right arg illegal
 <[a..c]>+ && <[b..e]>+	bcd		y	conjunction (&&)
 # todo :pugs<feature>
 <[a..d]>+ && <[c..e]>+	bcd		y	conjunction (&&)
-# todo :pge<&-conjunciton>
+# todo :any<&-conjunciton>
 b&			bcd		<rule error>	conjunction (&) - null right arg illegal
-# todo :pge<&-conjunciton>
+# todo :any<&-conjunciton>
 &b			bcd		<rule error>	conjunction (&) - null left arg illegal
-# todo :pge<&-conjunciton>
+# todo :any<&-conjunciton>
 &			bcd		<rule error>	conjunction (&) - null both args illegal
 \&			&		y	conjunction (&) - literal must be escaped
-# todo :pge<&-conjunciton>
+# todo :any<&-conjunciton>
 &			&		<rule error>	conjunction (&) - literal must be escaped
-# todo :pge<leading |>
+# todo :any<leading |>
 a&|b			a&|b		<rule error>	alternation and conjunction (&|) - parse error
-# todo :pge<&-conjunciton>
+# todo :any<&-conjunciton>
 &			&		<rule error>	conjunction (&) - literal must be escaped
-# todo :pge<&-conjunciton>
+# todo :any<&-conjunciton>
 a|&b			a|&b		<rule error>	alternation and conjunction (|&) - parse error
 |d|b			abc		y	leading alternation ignored
  |d|b			abc		y	leading alternation ignored
 |d |b			abc		y	leading alternation ignored
  | d | b		abc		y	leading alternation ignored
-# todo :pugs<feature> :pge<feature>
+# todo :pugs<feature>
+# todo :any<feature>
  b |  | d		abc		n	null pattern invalid
 \pabc			pabc		<Unrecognized>	retired metachars (\p)
 \p{InConsonant}		a		<Unrecognized>	retired metachars (\p)
@@ -139,9 +140,9 @@ a|&b			a|&b		<rule error>	alternation and conjunction (|&) - parse error
 \LABC\E			abc		<Unrecognized>	retired metachars (\L...\E)
 \Uabc\E			UabcE		<Unrecognized>	retired metachars (\U...\E)
 \Uabc\E			ABC		<Unrecognized>	retired metachars (\U...\E)
-# todo :pge<error messages>
+# todo :any<error messages>
 \Qabc\E			QabcE		<Unrecognized>	retired metachars (\Q...\E)
-# todo :pge<error messages>
+# todo :any<error messages>
 \Qabc d?\E		abc d		<Unrecognized>	retired metachars (\Q...\E)
 \Gabc			Gabc		<Unrecognized>	retired metachars (\G)
 \1abc			1abc		<Unrecognized>	retired metachars (\1)

--- a/t/qregex/rx_modifiers
+++ b/t/qregex/rx_modifiers
@@ -4,6 +4,9 @@
 :i ﬆ			St	y	ignorecase with ligature ﬆ (:i)
 :i ﬆ			sT	y	ignorecase with ligature ﬆ (:i)
 :i st			ﬆ	y	reversed haystack and needle ignorecase with ligature ﬆ (:i)
+
+# todo :moar<ligature problem>
+:i abcdefgﬆ			sT	y	ignorecase with ligature ﬆ (:i)
 :i bcd			abcdef	y	ignorecase (:i)
 :i bcd			aBcdef	y	ignorecase (:i)
 :i bcd			abCdef	y	ignorecase (:i)
@@ -129,19 +132,21 @@ foo '-'? bar			foo - bar	n	basic non-match
 # todo :pugs<feature>
 :s foo '-'? bar			foo-bar		y	basic ws match \s* \s*
 :s foo '-'? bar			foobar		n	basic ws non-match
-# todo :pge<feature>
+# todo :any<feature>
 :s()foo '-'? bar		foo - bar	n	basic ws match
-# todo :pugs<feature> :pge<feature>
+# todo :pugs<feature>
+# todo :any<feature>
 :s[]foo '-'? bar		foo - bar	y	basic ws match
 # todo :pugs<feature>
 :s<?wb>foo '-'? bar		foo - bar	y	basic ws match with boundary modifier separation
-# todo :pge<::>
+# todo :any<::>
 :s::foo '-'? bar			foo - bar	y	basic ws match with backtrack no-op modifier separation
-# todo :pge<::>
+# todo :any<::>
 :s::(\w+) ':=' (\S+)		dog := spot	/mob 0: <dog @ 0>/	sigspace and capture together
-# todo :pge<::>
+# todo :any<::>
 :s::(\w+) ':=' (\S+)		dog := spot	/mob 1: <spot @ 7>/	sigspace and capture together
-# todo :pugs<feature> :pge<feature>
+# todo :pugs<feature>
+# todo :any<feature>
 :perl5 \A.*? bcd\Q$\E..\z	a bcd$ef	y	perl5 syntax (:perl5)
 :s^[\d+ ]* abc			11 12 13 abc	y	<?ws> before closing bracket
 

--- a/t/qregex/rx_modifiers
+++ b/t/qregex/rx_modifiers
@@ -1,4 +1,5 @@
 ##  modifiers
+# todo 6 :jvm<ligature problem>
 :i ﬆ			st	y	ignorecase with ligature ﬆ (:i)
 :i ﬆ			ST	y	ignorecase with ligature ﬆ (:i)
 :i ﬆ			St	y	ignorecase with ligature ﬆ (:i)

--- a/t/qregex/rx_subrules
+++ b/t/qregex/rx_subrules
@@ -49,7 +49,7 @@ a<!wb>			abc\ndef\n-==\nghi	y	\w\w nonword boundary
 <+cntrl>+	\t\n\r !"#$%&'()*+,-./:;<=>?@[\]^`_{|}0123456789ABCDEFGHIJabcdefghij	<mob: \t\n\r @ 0>		<+cntrl>+
 <punct>		\t\n\r !"#$%&'()*+,-./:;<=>?@[\]^`_{|}0123456789ABCDEFGHIJabcdefghij	<mob<punct>: ! @ 4>		<punct>
 <+punct>	\t\n\r !"#$%&'()*+,-./:;<=>?@[\]^`_{|}0123456789ABCDEFGHIJabcdefghij	<mob: ! @ 4>			<+punct>
-# todo :pge<regression>
+# todo :any<regression>
 <+punct>+	\t\n\r !"#$%&'()*+,-./:;<=>?@[\]^`_{|}0123456789ABCDEFGHIJabcdefghij	<mob: !\\"#$%&/:;<=>?@[\\]^'_{|} @ 4>		<+punct>+
 <alnum>		\t\n\r !"#$%&'()*+,-./:;<=>?@[\]^`_{|}0123456789ABCDEFGHIJabcdefghij	<mob<alnum>: _ @ 31>		<alnum>
 <+alnum>	\t\n\r !"#$%&'()*+,-./:;<=>?@[\]^`_{|}0123456789ABCDEFGHIJabcdefghij	<mob: _ @ 31>	<+alnum>


### PR DESCRIPTION
Previously :pge<comment> would todo under all backends. This has been changed
to :any<comment>. It will also allow todoing under specific backends as well
(jvm and moar currently supported).