### PR TITLE
[moar] Use nqp::indexic op in QASTRegexCompilier

### DIFF
--- a/src/vm/moar/QAST/QASTRegexCompilerMAST.nqp
+++ b/src/vm/moar/QAST/QASTRegexCompilerMAST.nqp
@@ -1000,6 +1000,7 @@ class QAST::MASTRegexCompiler {
         }
         elsif $node.list && $node.subtype eq 'ignorecase' {
             my $lit := $!regalloc.fresh_s();
+            nqp::push(@ins, op('const_s', $lit, sval($node[0])));
             nqp::push(@ins, op('indexic_s', %!reg<pos>, %!reg<tgt>, $lit, %!reg<pos>));
             nqp::push(@ins, op('eq_i', $ireg0, %!reg<pos>, %!reg<negone>));
             $!regalloc.release_register($lit, $MVM_reg_str);

--- a/src/vm/moar/QAST/QASTRegexCompilerMAST.nqp
+++ b/src/vm/moar/QAST/QASTRegexCompilerMAST.nqp
@@ -151,7 +151,7 @@ class QAST::MASTRegexCompiler {
                 op('getattr_o', $curclass, $shared, $sharedclass, sval('$!CUR_CLASS'), ival(-1))
             ]);
         }
-        
+
         merge_ins(@ins, [
             op('getattr_s', $tgt, $shared, $sharedclass, sval('$!target'),
                 ival(nqp::hintfor(ParseShared, '$!target'))),
@@ -1000,16 +1000,7 @@ class QAST::MASTRegexCompiler {
         }
         elsif $node.list && $node.subtype eq 'ignorecase' {
             my $lit := $!regalloc.fresh_s();
-            nqp::push(@ins, op('const_s', $lit, sval(nqp::fc($node[0]))));
-            unless nqp::existskey(%!reg, 'haystacklc') {
-                %!reg<haystacklc> := $!regalloc.fresh_s();
-            }
-            my $no_need_lc := label();
-            nqp::push(@ins, op('isnull_s', $ireg0, %!reg<haystacklc>));
-            nqp::push(@ins, op('unless_i', $ireg0, $no_need_lc));
-            nqp::push(@ins, op('lc', %!reg<haystacklc>, %!reg<tgt>));
-            nqp::push(@ins, $no_need_lc);
-            nqp::push(@ins, op('index_s', %!reg<pos>, %!reg<haystacklc>, $lit, %!reg<pos>));
+            nqp::push(@ins, op('indexic_s', %!reg<pos>, %!reg<tgt>, $lit, %!reg<pos>));
             nqp::push(@ins, op('eq_i', $ireg0, %!reg<pos>, %!reg<negone>));
             $!regalloc.release_register($lit, $MVM_reg_str);
         }


### PR DESCRIPTION
The only remaining places in QASTRegexCompilier for MVM are used for
character ranges, which need to stay lc and uc to make character ranges
make sense.

This takes advantage of the MoarVM case insensitive string index operator,
giving us at least 1.8x speed boost doing case insensitive regex.