### PR TITLE
Make profile sql output better

### DIFF
--- a/src/vm/moar/HLL/Backend.nqp
+++ b/src/vm/moar/HLL/Backend.nqp
@@ -308,18 +308,21 @@ class HLL::Backend::MoarVM {
                 }
                 elsif $k eq 'call_graph' {
                     my %callee_rec_depth;
-                    sub collect_callees($caller, %call_graph) {
-                        my @callee := nqp::list_s(~$caller);
+                    my int $node_id := 0;
+                    sub collect_callees(str $caller_id, %call_graph) {
+                        my str $callee_id := ~$node_id;
+                        $node_id++;
+                        my @callee := nqp::list_s($caller_id, $callee_id);
                         for <id osr spesh_entries jit_entries inlined_entries inclusive_time exclusive_time entries deopt_one> -> $f {
                             nqp::push_s(@callee, ~(%call_graph{$f} // '0'));
                         }
-                        my str $id := ~$caller;
-                        %callee_rec_depth{$id} := 0 unless %callee_rec_depth{$id};
-                        nqp::push_s(@callee, ~%callee_rec_depth{$id});
-                        nqp::sayfh($profile_fh, 'INSERT INTO callees VALUES (' ~ nqp::join(',', @callee) ~ ');');
+                        my str $routine_id := ~%call_graph<id>;
+                        %callee_rec_depth{$routine_id} := 0 unless %callee_rec_depth{$routine_id};
+                        nqp::push_s(@callee, ~%callee_rec_depth{$routine_id});
+                        nqp::sayfh($profile_fh, 'INSERT INTO calls VALUES (' ~ nqp::join(',', @callee) ~ ');');
                         if %call_graph<allocations> {
                             for %call_graph<allocations> -> $a {
-                                my @a := nqp::list_s();
+                                my @a := nqp::list_s($caller_id, $callee_id);
                                 for <id spesh jit count> -> $f {
                                     nqp::push_s(@a, ~($a{$f} // '0'));
                                 }
@@ -327,14 +330,14 @@ class HLL::Backend::MoarVM {
                             }
                         }
                         if %call_graph<callees> {
-                            %callee_rec_depth{$id}++;
+                            %callee_rec_depth{$routine_id}++;
                             for %call_graph<callees> -> $c {
-                                collect_callees($id, $c);
+                                collect_callees(~$callee_id, $c);
                             }
-                            %callee_rec_depth{$id}--;
+                            %callee_rec_depth{$routine_id}--;
                         }
                     }
-                    collect_callees(-1, $v);
+                    collect_callees(~$node_id, $v);
                 }
             }
             nqp::sayfh($profile_fh, 'INSERT INTO profile VALUES (' ~ nqp::join(',', @profile) ~ ');');
@@ -357,8 +360,8 @@ class HLL::Backend::MoarVM {
             nqp::sayfh($profile_fh, 'CREATE TABLE routines(id INTEGER PRIMARY KEY ASC, name TEXT, line INT, file TEXT);');
             nqp::sayfh($profile_fh, 'CREATE TABLE profile(total_time INT, spesh_time INT);');
             nqp::sayfh($profile_fh, 'CREATE TABLE gcs(time INT, retained_bytes INT, promoted_bytes INT, gen2_roots INT, full INT, cleared_bytes INT);');
-            nqp::sayfh($profile_fh, 'CREATE TABLE callees(caller_id INT, id INT, osr INT, spesh_entries INT, jit_entries INT, inlined_entries INT, inclusive_time INT, exclusive_time INT, entries INT, deopt_one INT, rec_depth INT);');
-            nqp::sayfh($profile_fh, 'CREATE TABLE allocations(type_id INT, spesh INT, jit INT, count INT);');
+            nqp::sayfh($profile_fh, 'CREATE TABLE calls(caller_id INT, callee_id INT, routine_id INT, osr INT, spesh_entries INT, jit_entries INT, inlined_entries INT, inclusive_time INT, exclusive_time INT, entries INT, deopt_one INT, rec_depth INT);');
+            nqp::sayfh($profile_fh, 'CREATE TABLE allocations(caller_id INT, callee_id INT, type_id INT, spesh INT, jit INT, count INT);');
             to_sql($data);
             nqp::sayfh($profile_fh, 'END;');
         }

--- a/src/vm/moar/HLL/Backend.nqp
+++ b/src/vm/moar/HLL/Backend.nqp
@@ -286,7 +286,7 @@ class HLL::Backend::MoarVM {
                     nqp::sayfh($profile_fh, "INSERT INTO routines VALUES ('" ~ nqp::join("','", nqp::list(nqp::iterkey_s($k), literal_subst(~$v<name>, "'", "''"), ~$v<line>, ~$v<file>)) ~ "');");
                 }
                 else {
-                    nqp::sayfh($profile_fh, "INSERT INTO allocators VALUES ('" ~ nqp::join("','", nqp::list(nqp::iterkey_s($k), literal_subst(~$v, "'", "''"))) ~ "');");
+                    nqp::sayfh($profile_fh, "INSERT INTO types VALUES ('" ~ nqp::join("','", nqp::list(nqp::iterkey_s($k), literal_subst(~$v, "'", "''"))) ~ "');");
                 }
             }
             for $obj[1] -> $k {
@@ -353,12 +353,12 @@ class HLL::Backend::MoarVM {
         }
         elsif $want_sql {
             nqp::sayfh($profile_fh, 'BEGIN;');
-            nqp::sayfh($profile_fh, 'CREATE TABLE allocators(id INTEGER PRIMARY KEY ASC, name TEXT);');
+            nqp::sayfh($profile_fh, 'CREATE TABLE types(id INTEGER PRIMARY KEY ASC, name TEXT);');
             nqp::sayfh($profile_fh, 'CREATE TABLE routines(id INTEGER PRIMARY KEY ASC, name TEXT, line INT, file TEXT);');
             nqp::sayfh($profile_fh, 'CREATE TABLE profile(total_time INT, spesh_time INT);');
             nqp::sayfh($profile_fh, 'CREATE TABLE gcs(time INT, retained_bytes INT, promoted_bytes INT, gen2_roots INT, full INT, cleared_bytes INT);');
             nqp::sayfh($profile_fh, 'CREATE TABLE callees(caller_id INT, id INT, osr INT, spesh_entries INT, jit_entries INT, inlined_entries INT, inclusive_time INT, exclusive_time INT, entries INT, deopt_one INT, rec_depth INT);');
-            nqp::sayfh($profile_fh, 'CREATE TABLE allocations(id INT, spesh INT, jit INT, count INT);');
+            nqp::sayfh($profile_fh, 'CREATE TABLE allocations(type_id INT, spesh INT, jit INT, count INT);');
             to_sql($data);
             nqp::sayfh($profile_fh, 'END;');
         }

--- a/src/vm/moar/HLL/Backend.nqp
+++ b/src/vm/moar/HLL/Backend.nqp
@@ -301,7 +301,7 @@ class HLL::Backend::MoarVM {
                     for $v -> $gc {
                         my @g := nqp::list_s();
                         for <time retained_bytes promoted_bytes gen2_roots full cleared_bytes> -> $f {
-                            nqp::push_s(@g, ~($gc{$f} // 0));
+                            nqp::push_s(@g, ~($gc{$f} // '0'));
                         }
                         nqp::sayfh($profile_fh, 'INSERT INTO gcs VALUES (' ~ nqp::join(',', @g) ~ ');');
                     }
@@ -311,9 +311,9 @@ class HLL::Backend::MoarVM {
                     sub collect_callees($caller, %call_graph) {
                         my @callee := nqp::list_s(~$caller);
                         for <id osr spesh_entries jit_entries inlined_entries inclusive_time exclusive_time entries deopt_one> -> $f {
-                            nqp::push_s(@callee, ~(%call_graph{$f} // 0));
+                            nqp::push_s(@callee, ~(%call_graph{$f} // '0'));
                         }
-                        my str $id := ~%call_graph<id>;
+                        my str $id := ~$caller;
                         %callee_rec_depth{$id} := 0 unless %callee_rec_depth{$id};
                         nqp::push_s(@callee, ~%callee_rec_depth{$id});
                         nqp::sayfh($profile_fh, 'INSERT INTO callees VALUES (' ~ nqp::join(',', @callee) ~ ');');
@@ -321,7 +321,7 @@ class HLL::Backend::MoarVM {
                             for %call_graph<allocations> -> $a {
                                 my @a := nqp::list_s();
                                 for <id spesh jit count> -> $f {
-                                    nqp::push_s(@a, ~($a{$f} // 0));
+                                    nqp::push_s(@a, ~($a{$f} // '0'));
                                 }
                                 nqp::sayfh($profile_fh, 'INSERT INTO allocations VALUES (' ~ nqp::join(',', @a) ~ ');');
                             }

--- a/src/vm/moar/HLL/Backend.nqp
+++ b/src/vm/moar/HLL/Backend.nqp
@@ -301,7 +301,7 @@ class HLL::Backend::MoarVM {
                     for $v -> $gc {
                         my @g := nqp::list_s();
                         for <time retained_bytes promoted_bytes gen2_roots full cleared_bytes> -> $f {
-                            nqp::push_s(@g, ~($gc{$f} // 'NULL'));
+                            nqp::push_s(@g, ~($gc{$f} // 0));
                         }
                         nqp::sayfh($profile_fh, 'INSERT INTO gcs VALUES (' ~ nqp::join(',', @g) ~ ');');
                     }
@@ -311,7 +311,7 @@ class HLL::Backend::MoarVM {
                     sub collect_callees($caller, %call_graph) {
                         my @callee := nqp::list_s(~$caller);
                         for <id osr spesh_entries jit_entries inlined_entries inclusive_time exclusive_time entries deopt_one> -> $f {
-                            nqp::push_s(@callee, ~(%call_graph{$f} // 'NULL'));
+                            nqp::push_s(@callee, ~(%call_graph{$f} // 0));
                         }
                         my str $id := ~%call_graph<id>;
                         %callee_rec_depth{$id} := 0 unless %callee_rec_depth{$id};
@@ -321,7 +321,7 @@ class HLL::Backend::MoarVM {
                             for %call_graph<allocations> -> $a {
                                 my @a := nqp::list_s();
                                 for <id spesh jit count> -> $f {
-                                    nqp::push_s(@a, ~($a{$f} // 'NULL'));
+                                    nqp::push_s(@a, ~($a{$f} // 0));
                                 }
                                 nqp::sayfh($profile_fh, 'INSERT INTO allocations VALUES (' ~ nqp::join(',', @a) ~ ');');
                             }


### PR DESCRIPTION
Change two table names: `allocators` -> `types` and `callees` -> `calls`

Use `0`s instead of `NULL`s when there's no value (unneeded carry-over from a JSON output optimization).

Rename `id` fields that refer to another table's `id` field to `<other table>_id`.

Add the necessary information to the `allocations` table such that all the functionality of the "Allocations" tab in the HTML profile can be replicated.

Change the `caller_id` and `callee_id` in the `calls` table such that it's possible to find out what
routines call a particular routine.