### PR TITLE
Fix for RT #130760

### DIFF
--- a/src/HLL/Compiler.nqp
+++ b/src/HLL/Compiler.nqp
@@ -329,8 +329,8 @@ class HLL::Compiler does HLL::Backend::Default {
         try {
             $res := $p.parse(@args);
             CATCH {
-                nqp::say($_);
-                self.usage;
+                nqp::sayfh(nqp::getstderr(), $_);
+                self.usage(:use-stderr);
                 nqp::exit(1);
             }
         }
@@ -512,15 +512,16 @@ class HLL::Compiler does HLL::Backend::Default {
         }
     }
 
-    method usage($name?) {
+    method usage($name?, :$use-stderr = False) {
+        my $print-func := $use-stderr ?? &note !! &say; # RT #130760
         if $name {
-            say($name);
+            $print-func($name);
         }
         my $usage := "This compiler is based on HLL::Compiler.\n\nOptions:\n";
         for @!cmdoptions {
             $usage := $usage ~ "    $_\n";
         }
-        nqp::say($usage);
+        $print-func($usage);
         nqp::exit(0);
     }
 


### PR DESCRIPTION
Entering an invalid option when invoking nqp or perl6 leads to an
error message being printed followed by usage instructions. In both
cases this information is written to stdout when it should have been
written to stderr. This fix solves the problem for nqp by introducing
a flag which tells the code doing the writing which fd to use.
In order to fix perl6 a separate Rakudo PR is necessary. That fix
will be dependent on this one but it won't break anything even if this
fix is reverted, it will just continue to work the way it does today.