### PR TITLE
Zero slot when popping an array

### DIFF
--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance.java
@@ -125,7 +125,9 @@ public class VMArrayInstance extends VMArrayInstanceBase {
         if (elems < 1)
             throw ExceptionHandling.dieInternal(tc, "VMArray: Can't pop from an empty array");
         elems--;
-        return slots[start + elems];
+        SixModelObject popped = slots[start + elems];
+        slots[start + elems] = null;
+        return popped;
     }
 
     public void unshift_boxed(ThreadContext tc, SixModelObject value) {


### PR DESCRIPTION
Otherwise ghost elements are left.

Fixes https://rt.perl.org/Ticket/Display.html?id=131245 for the JVM.

Previously `perl6 -e 'my @a=(1,2,3,4,5); @a.pop; @a.pop, @a[4]="hi"; say @a.join(",");'` would print `1,2,3,4,hi`, now it prints `1,2,3,,hi`.

NQP passes `make j-test` and Rakudo builds and I'm currently running a `make j-spectest`.