### PR TITLE
Add .gist method to NQPRoutine

### DIFF
--- a/src/core/NQPRoutine.nqp
+++ b/src/core/NQPRoutine.nqp
@@ -346,6 +346,10 @@ my knowhow NQPRoutine {
     }
     
     method signature() { $!signature }
+
+    method gist() {
+        self.name()
+    }
 }
 nqp::setinvokespec(NQPRoutine, NQPRoutine, '$!do', nqp::null);
 #?if moar


### PR DESCRIPTION
This way `say Match.^methods` doesn't die with `X::Method::NotFound
exception produced no message`.

NQP passes `make m-test` and Rakudo passes `make m-spectest`.