### PR TITLE
Fix 'Substr length cannot be negative' from Match

### DIFF
--- a/src/QRegex/Cursor.nqp
+++ b/src/QRegex/Cursor.nqp
@@ -87,11 +87,11 @@ role NQPMatchRole is export {
     method to()     { $!to < 0 ?? $!pos !! $!to }
     method CURSOR() { self }
     method PRECURSOR() { self."!cursor_init"(nqp::getattr($!shared, ParseShared, '$!target'), :p($!from)) }
-    method Str()       { $!pos >= $!from ?? nqp::substr(nqp::getattr($!shared, ParseShared, '$!target'), $!from, nqp::sub_i(self.to, $!from)) !! '' }
+    method Str()       { $!pos >= $!from ?? nqp::substr(nqp::getattr($!shared, ParseShared, '$!target'), $!from, nqp::sub_i(($!to < 0 ?? $!pos !! $!to), $!from)) !! '' }
     method Int()       { my int $i := +self.Str(); $i }  # XXX need a better way to do this
     method Num()       { +self.Str() }
     method Bool()      { $!pos >= $!from }
-    method chars()     { $!pos >= $!from ?? nqp::sub_i(self.to, $!from) !! 0 }
+    method chars()     { $!pos >= $!from ?? nqp::sub_i(($!to < 0 ?? $!pos !! $!to), $!from) !! 0 }
 
     method make($made)  { $!made := $made }
     method made()       { $!made }


### PR DESCRIPTION
I don't understand why this should change anything, but it does.

Fixes Grammar::HTTP - see:
https://github.com/ugexe/Perl6-Grammar--HTTP/issues/6
https://irclog.perlgeek.de/perl6-dev/2017-05-02#i_14521237