### PR TITLE
Make backtracking modifiers on alternations work correctly

### DIFF
--- a/src/QRegex/P6Regex/Actions.nqp
+++ b/src/QRegex/P6Regex/Actions.nqp
@@ -113,7 +113,7 @@ class QRegex::P6Regex::Actions is HLL::Actions {
         $qast := QAST::Regex.new(:rxtype<concat>, $qast, $sigfinal) if $sigfinal;
 
         if $qast {
-            $qast.backtrack('r') if !$qast.backtrack && (%*RX<r> || $<backmod> && ~$<backmod> eq ':');
+            $qast.backtrack('r') if !$qast.backtrack && nqp::if($<backmod>, (~$<backmod> eq ':'), %*RX<r>);
             $qast.node($/);
         }
         make $qast;

--- a/src/vm/jvm/QAST/Compiler.nqp
+++ b/src/vm/jvm/QAST/Compiler.nqp
@@ -5264,6 +5264,12 @@ class QAST::CompilerJAST {
         my $endlabel := JAST::Label.new( :name($prefix ~ 'end') );
         my $altlabel := JAST::Label.new( :name($prefix ~ $altcount) );
         my $ajast    := self.regex_jast(nqp::shift($iter));
+
+        my $mark_endlabel := &*REGISTER_MARK($endlabel);
+        self.regex_mark($il, $mark_endlabel,
+            $IVAL_MINUSONE,
+            $IVAL_ZERO);
+
         while $iter {
             $il.append($altlabel);
             $altcount++;
@@ -5273,6 +5279,7 @@ class QAST::CompilerJAST {
                 JAST::Instruction.new( :op('lload'), %*REG<pos> ),
                 $IVAL_ZERO);
             $il.append($ajast);
+            self.regex_commit($il, $mark_endlabel) if $node.backtrack eq 'r';
             $il.append(JAST::Instruction.new( :op('goto'), $endlabel ));
             $ajast := self.regex_jast(nqp::shift($iter));
         }

--- a/src/vm/moar/QAST/QASTRegexCompilerMAST.nqp
+++ b/src/vm/moar/QAST/QASTRegexCompilerMAST.nqp
@@ -316,6 +316,7 @@ class QAST::MASTRegexCompiler {
         my $altlabel_index := self.rxjump();
         my $altlabel := @!rxjumps[$altlabel_index];
         my @amast    := self.regex_mast(nqp::shift($iter));
+        self.regex_mark(@ins, $endlabel_index, %!reg<negone>, %!reg<zero>);
         while $iter {
             nqp::push(@ins, $altlabel);
             $altcount++;
@@ -323,6 +324,7 @@ class QAST::MASTRegexCompiler {
             $altlabel := @!rxjumps[$altlabel_index];
             self.regex_mark(@ins, $altlabel_index, %!reg<pos>, %!reg<zero>);
             merge_ins(@ins, @amast);
+            self.regex_commit(@ins, $endlabel_index) if $node.backtrack eq 'r';
             nqp::push(@ins, op('goto', $endlabel));
             @amast := self.regex_mast(nqp::shift($iter));
         }


### PR DESCRIPTION
### Summary

Current Rakudo behavior:

| _Backtrackable atom:_ | `?` | `*` | `+` | `**` | `\|` | `\|\|` |
|--|--|--|--|--|--|--|
| *Respects default (eager backtracking) mode:* | yes | yes | yes | yes | yes | yes |
| *Respects ratchet mode:* | yes | yes | yes | yes | yes | **no** |
| *Respects atom-specific backtracking modifier:* | yes | yes | yes | yes | yes | **no** |
| *Atom-specific backmod overrides ratchet mode:* | yes | yes | yes | yes | **no** | **n/a** |

With this pull request, the behavior becomes "**yes**" for all 24 cases.

### Implementation

Please review carefully, because these are my first commits to nqp and my understanding of this code base is limited... 😃
I basically just copied the existing no-backtrack handling code from `method alt` to `method altseq` in both the MoarVM and JVM backend ([263257a](https://github.com/perl6/nqp/pull/368/commits/263257a)), and fixed a thinko in the `quantified_atom` action method where the "backtrack" flag for alternation atoms is set in the first place ([ba165c8](https://github.com/perl6/nqp/pull/368/commits/ba165c8)).

### RT & SYN

This fixes:

* [RT #130117](https://rt.perl.org/Ticket/Display.html?id=130117)
* [RT #131973](https://rt.perl.org/Ticket/Display.html?id=131973)

It also matches the behavior intended for these backtracking modifiers by [S05](http://design.perl6.org/S05.html#line_621), as I understand it.

### Roast

This PR passed `make spectest` on my machine (Linux/MoarVM) .

One it's merged, I'd suggest adding the following additional tests to roast:

``` Perl 6
use Test;
plan 24;

is "ab" ~~ / a .? b /,            "ab", "backtrack into ?";
is "ab" ~~ / a .?: b /,           Nil,  "don't backtrack into ?:";
is "ab" ~~ / :r a .? b /,         Nil,  "don't backtrack into ? after :r";
is "ab" ~~ / :r a .?! b /,        "ab", "backtrack into ?! (overrides :r)";

is "ab" ~~ / a .* b /,            "ab", "backtrack into *";
is "ab" ~~ / a .*: b /,           Nil,  "don't backtrack into *:";
is "ab" ~~ / :r a .* b /,         Nil,  "don't backtrack into * after :r";
is "ab" ~~ / :r a .*! b /,        "ab", "backtrack into *! (overrides :r)";

is "ab" ~~ / .+ b /,              "ab", "backtrack into +";
is "ab" ~~ / .+: b /,             Nil,  "don't backtrack into +:";
is "ab" ~~ / :r .+ b /,           Nil,  "don't backtrack into + after :r";
is "ab" ~~ / :r .+! b /,          "ab", "backtrack into +! (overrides :r)";

is "ab" ~~ / . ** 1..3 b /,       "ab", "backtrack into **";
is "ab" ~~ / . **: 1..3 b /,      Nil,  "don't backtrack into **:";
is "ab" ~~ / :r . ** 1..3 b /,    Nil,  "don't backtrack into ** after :r";
is "ab" ~~ / :r . **! 1..3 b /,   "ab", "backtrack into **! (overrides :r)";

is "ab" ~~ / [ab | a ] b /,       "ab", "backtrack into |";
is "ab" ~~ / [ab | a ]: b /,      Nil,  "don't backtrack into | with :";
is "ab" ~~ / :r [ab | a ] b /,    Nil,  "don't backtrack into | after :r";
is "ab" ~~ / :r [ab | a ]:! b /,  "ab", "backtrack into | with :! (overrides :r)";

is "ab" ~~ / [ab || a ] b /,      "ab", "backtrack into ||";
is "ab" ~~ / [ab || a ]: b /,     Nil,  "don't backtrack into || with :";
is "ab" ~~ / :r [ab || a ] b /,   Nil,  "don't backtrack into || after :r";
is "ab" ~~ / :r [ab || a ]:! b /, "ab", "backtrack into || with :! (overrides :r)";
```
Of these tests, the following three fail without this PR:

```
not ok 20 - backtrack into | with :! (overrides :r)
not ok 22 - don't backtrack into || with :
not ok 23 - don't backtrack into || after :r
```

With this PR applied, all 24 tests succeed.