### PR TITLE
[jvm] Don't wait for child when program ends

### DIFF
--- a/src/vm/jvm/runtime/org/perl6/nqp/io/AsyncProcessHandle.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/io/AsyncProcessHandle.java
@@ -46,7 +46,7 @@ public class AsyncProcessHandle implements IIOClosable {
         this.tc = tc;
         this.hllConfig = tc.curFrame.codeRef.staticInfo.compUnit.hllConfig;
         this.bufType = config.get("buf_type");
-        new Thread(new Runnable() {
+        Thread thread = new Thread(new Runnable() {
             public void run() {
                 try {
                     AsyncProcessHandle.this.proc = pb.start();
@@ -88,7 +88,9 @@ public class AsyncProcessHandle implements IIOClosable {
                                 AsyncProcessHandle.this.hllConfig.strBoxType, message);
                 }
             }
-        }).start();
+        });
+        thread.setDaemon(true);
+        thread.start();
     }
 
     private List<String> getArgs(ThreadContext tc, SixModelObject argsObj) {


### PR DESCRIPTION
With a user thread the following program sleeps for another 18 seconds
after saying bye:

  my $proc = Proc::Async.new('sleep', '20');
  my $promise = $proc.start;
  sleep 2;
  say 'bye';

With a daemon thread the program exits after saying bye. The child
process runs for another 18 seconds on its own. That's the behaviour
with MoarVM as well.