### PR TITLE
Add getppid op for moarvm

### DIFF
--- a/docs/ops.markdown
+++ b/docs/ops.markdown
@@ -297,6 +297,7 @@
   * [getenvhash](#getenvhash)
   * [backendconfig](#backendconfig)
   * [getpid](#getpid)
+  * [getppid `moar`](#getppid)
   * [jvmclasspaths `jvm`](#jvmclasspaths-jvm)
   * [sha1](#sha1)
   * [sleep](#sleep)
@@ -2483,6 +2484,11 @@ configure and build flags.
 * `getpid()`
 
 Return the current process id, an int.
+
+## getppid `moar`
+* `getppid()`
+
+Return the process id of the parent process, an int.
 
 ## jvmclasspaths `jvm`
 * `jvmclasspaths()`

--- a/src/vm/moar/QAST/QASTOperationsMAST.nqp
+++ b/src/vm/moar/QAST/QASTOperationsMAST.nqp
@@ -2853,6 +2853,7 @@ QAST::MASTOperations.add_core_moarop_mapping('exit', 'exit', 0);
 QAST::MASTOperations.add_core_moarop_mapping('sleep', 'sleep', 0);
 QAST::MASTOperations.add_core_moarop_mapping('getenvhash', 'getenvhash');
 QAST::MASTOperations.add_core_moarop_mapping('getpid', 'getpid');
+QAST::MASTOperations.add_core_moarop_mapping('getppid', 'getppid');
 QAST::MASTOperations.add_core_moarop_mapping('gethostname', 'gethostname');
 QAST::MASTOperations.add_core_moarop_mapping('rand_i', 'rand_i');
 QAST::MASTOperations.add_core_moarop_mapping('rand_n', 'randscale_n');


### PR DESCRIPTION
Allows a child process to get the parent process id, and thus guess if it has become orphaned.