### PR TITLE
add new pod tests

### DIFF
--- a/t/nqp/005-comments.t
+++ b/t/nqp/005-comments.t
@@ -2,7 +2,7 @@
 
 # check comments
 
-say('1..8');
+say('1..16');
 
 #Comment preceding
 say("ok 1");
@@ -54,4 +54,44 @@ say("ok 7");
 
     say("ok 8");
 
+    =begin comment
+    this is indented pod with an unaligned =end comment
+      =end comment
+say("ok 9");
 
+
+    =begin comment
+    this is another indented pod with an unaligned =end comment
+  =end comment
+say("ok 10");
+
+# Parsing breaks down here: no errors are found
+# with the second =end and how it's interpreted.
+# seems to be a pod object of unknown type.
+# the second =begin seems to be ignored or
+# considered part of the comment.
+# may need a :nested config key
+    =begin comment
+    this is indented pod with an unaligned =end comment
+    =begin comment
+    this is a nested comment
+  =end comment
+    say("ok 11");
+
+    say("ok 12");
+  # the following doesn't trigger a panic:
+  =end comment
+
+say("ok 13");
+
+
+=begin comment
+this is indented pod with an unaligned =end comment
+ =begin comment
+ this is a nested comment
+ =end comment
+say("ok 14");
+say("ok 15");
+# the following triggers a panic if uncommented:
+#=end comment
+say("ok 16");


### PR DESCRIPTION
+ test for robust =end for blocks even though misaligned with its =begin

+ test to show current state of failure with nested comment blocks
  that shows parsing of code ends at the first =end comment
  OR an error is thrown in other circumstances