### PR TITLE
Don't die if QAST parent doesn't have dump_extra_node_info method

### DIFF
--- a/src/QAST/SpecialArg.nqp
+++ b/src/QAST/SpecialArg.nqp
@@ -15,8 +15,18 @@ role QAST::SpecialArg {
     }
 
     method dump_extra_node_info() {
-        my $parent := self.HOW.parents(self, :local(1))[0];
-        my $info := $parent.HOW.method_table($parent)<dump_extra_node_info>(self);
+        my $info := {
+            my @parents := self.HOW.parents(self);
+            nqp::shift(@parents) if +@parents > 0;
+
+            my $meth;
+            my $invokable := 0;
+            for @parents -> $p {
+                $meth := $p.HOW.method_table($p)<dump_extra_node_info>;
+                last if ( $invokable := nqp::isinvokable($meth) );
+            }
+            $invokable ?? $meth(self) !! ''
+        }();
 
         $info := nqp::chars($info) ?? $info ~ " " !! "";
 

--- a/t/qast/01-qast.t
+++ b/t/qast/01-qast.t
@@ -1,6 +1,6 @@
 use QAST;
 
-plan(166);
+plan(167);
 
 # Following a test infrastructure.
 sub compile_qast($qast) {
@@ -2511,4 +2511,20 @@ is_qast(
             )
         ),
         'survived', 'wrong number of arguments lives with custom_args');
+}
+
+# QAST::SpecialArg: if parent doesn't have dump_extra_node_info method, don't die.
+{
+    my $node := QAST::Want.new( :named('somename') );
+
+    my $info := '';
+    my $died := 0;
+    {
+        $info := $node.dump_extra_node_info();
+        CATCH { $died := 1; }
+    }
+
+    ok( nqp::cmp_i($died, 0) == 0,
+        "SpecialArg: Parent doesn't have dump_extra_node_info; doesn't die"
+    );
 }


### PR DESCRIPTION
The dump_extra_node_info method of the QAST::SpecialArg role would look
up the method of the same name on the immediate parent and invoke it,
dying if that method didn't exist and could not be invoked (like when mixed-in
to QAST::Want, for instance). Modifying the behavior so that it checks
whether the there is an invokable method, and if not continue along the
parent chain until one is found or all are exhausted.