### PR TITLE
add a test for stderr in spawnprocasync

### DIFF
--- a/t/nqp/111-spawnprocasync.t
+++ b/t/nqp/111-spawnprocasync.t
@@ -54,7 +54,7 @@ my $config := nqp::hash(
 );
 
 # define a task
-$string  := "expected output";
+$string  := "expected output from stdout";
 $command := "echo $string";
 $args := $is-windows ?? nqp::list(nqp::getenvhash()<ComSpec>, '/c', $command)
                      !! nqp::list('/bin/sh', '-c', $command);
@@ -65,11 +65,11 @@ nqp::permit($task, 1, -1);
 while !$done || !$read_all {
   if nqp::shift($queue) -> $task {
     if nqp::list($task) {
-      my $code := nqp::shift($task);
-      $code(|$task);
+        my $code := nqp::shift($task);
+        $code(|$task);
     }
     else {
-      $task();
+        $task();
     }
   }
 }
@@ -89,7 +89,7 @@ $read_all     := 0;
 $called_ready := 0;
 
 # define the task
-$string  := "expected output";
+$string  := "expected output from stderr";
 $command := "echo $string >&2";
 $args := $is-windows ?? nqp::list(nqp::getenvhash()<ComSpec>, '/c', $command)
                      !! nqp::list('/bin/sh', '-c', $command);
@@ -100,11 +100,11 @@ nqp::permit($task, 2, -1);
 while !$done || !$read_all {
   if nqp::shift($queue) -> $task {
     if nqp::list($task) {
-      my $code := nqp::shift($task);
-      $code(|$task);
+        my $code := nqp::shift($task);
+        $code(|$task);
     }
     else {
-      $task();
+        $task();
     }
   }
 }

--- a/t/nqp/111-spawnprocasync.t
+++ b/t/nqp/111-spawnprocasync.t
@@ -1,9 +1,12 @@
-plan(2);
+plan(4);
 
+# set up reusable scaffolding
 my $is-windows := nqp::backendconfig()<osname> eq 'MSWin32';
-
-my $args := $is-windows ?? nqp::list(nqp::getenvhash()<ComSpec>, '/c', 'echo aardvarks') !! nqp::list('/bin/sh', '-c', 'echo aardvarks');
-
+my class Queue is repr('ConcBlockingQueue') { }
+my $queue := nqp::create(Queue);
+my class VMDecoder is repr('Decoder') {}
+my $dec := nqp::create(VMDecoder);
+nqp::decoderconfigure($dec, 'utf8', nqp::hash());
 my sub create_buf($type) {
     my $buf := nqp::newtype(nqp::null(), 'VMArray');
     nqp::composetype($buf, nqp::hash('array', nqp::hash('type', $type)));
@@ -11,22 +14,22 @@ my sub create_buf($type) {
     $buf;
 }
 
-my $done := 0;
-
-my class Queue is repr('ConcBlockingQueue') { }
-my $queue := nqp::create(Queue);
-
-my @stdout_bytes;
-my $read_all := 0;
-
+# reusable vars
+my str $s; # for testing output
+my $regex;
+# reusable vars needing reset
+my $done         := 0;
+my $read_all     := 0;
 my $called_ready := 0;
 
-
+# task-specific vars
+my @stdout_bytes;
+my @stderr_bytes;
 my $config := nqp::hash(
     'done', -> $status {
         $done := $done + 1;
     },
-    'ready', -> $stdin?, $stdout? {
+    'ready', -> $stdin?, $stdout?, $stderr? {
         $called_ready := $called_ready + 1;
     },
     'stdout_bytes', -> $seq, $data, $err {
@@ -37,32 +40,80 @@ my $config := nqp::hash(
             $read_all := 1;
         }
     },
+    'stderr_bytes', -> $seq, $data, $err {
+        if nqp::isconcrete($data) {
+            @stderr_bytes[$seq] := $data;
+        }
+        else {
+            $read_all := 1;
+        }
+    },
     'buf_type', create_buf(uint8)
 );
 
-
+# define a task
+my $args := $is-windows ?? nqp::list(nqp::getenvhash()<ComSpec>, '/c', 'echo aardvarks')
+                        !! nqp::list('/bin/sh', '-c', 'echo aardvarks');
 my $task := nqp::spawnprocasync($queue, $args, nqp::cwd(), nqp::getenvhash(), $config);
-
 nqp::permit($task, 1, -1);
 
+# run the task
 while !$done || !$read_all {
   if nqp::shift($queue) -> $task {
     if nqp::list($task) {
       my $code := nqp::shift($task);
       $code(|$task);
-    } else {
+    }
+    else {
       $task();
     }
   }
 }
 
-my class VMDecoder is repr('Decoder') {}
-my $dec := nqp::create(VMDecoder);
-nqp::decoderconfigure($dec, 'utf8', nqp::hash());
-
+# check results
 is($called_ready, 1, 'called the ready callback once');
-
 for @stdout_bytes -> $bytes {
     nqp::decoderaddbytes($dec, $bytes);
 }
-ok(nqp::decodertakeallchars($dec) ~~ /^aardvarks\s*$/, 'got the correct output');
+$s := nqp::decodertakeallchars($dec);
+ok($s ~~ /^aardvarks\s*$/, 'got the correct output on stdout');
+
+#== test for stderr ============
+# reset some reusable vars
+$done         := 0;
+$read_all     := 0;
+$called_ready := 0;
+
+# define the task
+$args := $is-windows ?? nqp::list(nqp::getenvhash()<ComSpec>, '/c', 'foo')
+                     !! nqp::list('/bin/sh', '-c', 'foo');
+$task := nqp::spawnprocasync($queue, $args, nqp::cwd(), nqp::getenvhash(), $config);
+nqp::permit($task, 2, -1);
+
+# run the task
+while !$done || !$read_all {
+  if nqp::shift($queue) -> $task {
+    if nqp::list($task) {
+      my $code := nqp::shift($task);
+      $code(|$task);
+    }
+    else {
+      $task();
+    }
+  }
+}
+
+# check results
+is($called_ready, 1, 'called the ready callback once');
+for @stderr_bytes -> $bytes {
+    nqp::decoderaddbytes($dec, $bytes);
+}
+$s := nqp::decodertakeallchars($dec);
+
+if nqp::getcomp('nqp').backend.name eq 'jvm' {
+    skip("no output from spawnprocasync stderr on the jvm", 1);
+}
+else {
+    ok($s  ~~ / '/bin/sh:' \s+ \d+ ':' \s+ foo \s* ':' \s* not \s* found/,
+       'got the correct output on stderr');
+}


### PR DESCRIPTION
+ provides a partial fix for nqp GH #409 (no test for merge yet)
+ note the test for stderr on moarvm is good, but it is skipped for the
  jvm because something appears to be wrong with the stderr stream
  interface there
+ adds comments for the tests
+ organizes the code to be more readable