### PR TITLE
rename IO sub "spew" to "spurt"

### DIFF
--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -41,8 +41,8 @@ Close the file attached to file handle `$fh`.
 
 Returns the contents of `$filename` as a single string.
 
-## spew
-* `spew($filename, $contents)`
+## spurt
+* `spurt($filename, $contents)`
 
 Write the string value of `$contents` to `$filename`.
 
@@ -87,18 +87,18 @@ Returns a file handle to `stderr`.
 Some methods available on the file handle (fh) returned from `open`.
 Other methods available of lesser interest not documented below are:
 + flush
-+ get
 + seek
 + set-encoding
 + set-nl-in
++ slurp
 + t
 + tell
 + wrap
 
-## fh.slurp
-* `$fh.slurp()`
+## fh.get
+* `$fh.get()`
 
-Reads the entire file attached to file handle `$fh`.
+Reads a line from the file attached to file handle `$fh`.
 
 ## fh.print
 * `$fh.print($string)`

--- a/src/core/IO.nqp
+++ b/src/core/IO.nqp
@@ -262,11 +262,11 @@ sub slurp ($filename) {
     $contents
 }
 
-=begin item spew
+=begin item spurt
 Write the string value of C<$contents> to C<$filename>.
 =end item
 
-sub spew($filename, $contents) {
+sub spurt($filename, $contents) {
     my $handle := open($filename, :w);
     $handle.print($contents);
     $handle.close;

--- a/t/nqp/019-file-ops.t
+++ b/t/nqp/019-file-ops.t
@@ -2,7 +2,7 @@
 
 # Test nqp::op file operations.
 
-plan(107);
+plan(109);
 
 ok( nqp::stat('CREDITS', nqp::const::STAT_EXISTS) == 1, 'nqp::stat exists');
 ok( nqp::stat('AARDVARKS', nqp::const::STAT_EXISTS) == 0, 'nqp::stat not exists');
@@ -465,4 +465,14 @@ my sub create_buf($type) {
     nqp::unlink($dir ~ '/file1');
     nqp::unlink($dir ~ '/file2');
     nqp::rmdir($dir);
+}
+
+# test spurt
+{
+    my $s := "line 1\nline 2";
+    spurt($test-file, $s);
+    my $fh := open($test-file);
+    is($fh.get(), 'line 1', 'read from spurted line 1 ok');
+    is($fh.get(), 'line 2', 'read from spurted line 2 ok');
+    nqp::unlink($test-file);
 }


### PR DESCRIPTION
changes to file "src/core/IO.nqp":
+ rename sub "spew" to "spurt" for consistency with
  the rest of Perl

changes to file "t/nqp/019-file-ops.t":
+ add tests for sub "spurt"

changes to file "docs/built-ins.md":
+ change "spew" to "spurt" in subs
+ add "get" to the documented methods on a file handle
+ remove full documentation on the slurp method
  on a file handle (but add it the the list
  of available file handle methods)