### PR TITLE
Rakudo RT#102994: Add flag indicating HLL init status in StaticInfo

### DIFF
--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/StaticCodeInfo.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/StaticCodeInfo.java
@@ -59,6 +59,11 @@ public class StaticCodeInfo implements Cloneable {
     public byte[] oLexStaticFlags;
 
     /**
+     * Has the given lexical been assigned a value by the HLL?
+     */
+    public boolean[] oLexStaticIsHllInit;
+
+    /**
      * Names of the lexicals we have of each of the base types.
      */
     public String[] oLexicalNames;
@@ -172,6 +177,7 @@ public class StaticCodeInfo implements Cloneable {
         if (oLexicalNames != null) {
             this.oLexStatic = new SixModelObject[oLexicalNames.length];
             this.oLexStaticFlags = new byte[oLexicalNames.length];
+            this.oLexStaticIsHllInit = new boolean[oLexicalNames.length];
         }
         this.argsExpectation = argsExpectation;
         MethodType t = mh.type();
@@ -209,6 +215,7 @@ public class StaticCodeInfo implements Cloneable {
             if (result.oLexStatic != null) {
                 result.oLexStatic = result.oLexStatic.clone();
                 result.oLexStaticFlags = result.oLexStaticFlags.clone();
+                result.oLexStaticIsHllInit = result.oLexStaticIsHllInit.clone();
             }
             return result;
         }


### PR DESCRIPTION
Add a value that indicates whether the static lexical has been assigned
a value by the HLL (flag set via extop on HLL side).

This change is being made to coincide with a Rakudo development
regarding statevar initialization.

See [RT#102994](https://rt.perl.org/Public/Bug/Display.html?id=102994)