### PR TITLE
Fix eof detection on zero-size files

### DIFF
--- a/src/vm/jvm/runtime/org/perl6/nqp/io/FileHandle.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/io/FileHandle.java
@@ -152,7 +152,7 @@ public class FileHandle extends SyncHandle implements IIOSeekable, IIOLockable {
             return false;
         else {
             try {
-                eof = fc.position() >= fc.size();
+                eof = fc.size() > 0 && fc.position() >= fc.size();
                 return eof;
             }
             catch (Exception e) {

--- a/src/vm/jvm/runtime/org/perl6/nqp/io/FileHandle.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/io/FileHandle.java
@@ -19,7 +19,6 @@ public class FileHandle extends SyncHandle implements IIOSeekable, IIOLockable {
 
     FileChannel fc;
     FileLock lock;
-    protected boolean eof = false;
 
     public static OpenOption[] resolveOpenMode(String mode) {
         if(mode.length() == 0)


### PR DESCRIPTION
Should help with https://github.com/rakudo/rakudo/issues/1541

There is still an issue with failing spectest for eof on Rakudo that use .read, but I think those are caused by something else.