### PR TITLE
Rakudo RT#102994: Add flag indicating HLL init status in CodeRef (CodeRef edition)

### DIFF
--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/CallFrame.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/CallFrame.java
@@ -138,6 +138,7 @@ public class CallFrame implements Cloneable {
             int numoLex = sci.oLexStatic.length;
             this.oLex = new SixModelObject[numoLex];
             for (int i = 0; i < numoLex; i++) {
+                // 0 = static, 1 = clone, 2 = state
                 switch (sci.oLexStaticFlags[i]) {
                 case 0:
                     this.oLex[i] = sci.oLexStatic[i];
@@ -148,6 +149,7 @@ public class CallFrame implements Cloneable {
                 case 2:
                     if (cr.oLexState == null) {
                         cr.oLexState = new SixModelObject[sci.oLexStatic.length];
+                        cr.oLexStateIsHllInit = new boolean[sci.oLexStatic.length];
                         this.stateInit = true;
                     }
                     if (cr.oLexState[i] == null)

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/CodeRef.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/CodeRef.java
@@ -39,6 +39,11 @@ public class CodeRef extends SixModelObject {
     public SixModelObject[] oLexState;
 
     /**
+     * Has the given statevar been assigned a value by the HLL?
+     */
+    public boolean[] oLexStateIsHllInit;
+
+    /**
      * The (human-readable) name of the code-ref (not in staticInfo as a
      * number of places want to tweak it per closure clone).
      */

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/StaticCodeInfo.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/StaticCodeInfo.java
@@ -55,6 +55,7 @@ public class StaticCodeInfo implements Cloneable {
 
     /**
      * Flags for each static lexical usage.
+     * 0 = static, 1 = clone, 2 = state
      */
     public byte[] oLexStaticFlags;
 


### PR DESCRIPTION
Add a value that indicates whether the statevar associated with the
coderef has been assigned a value by the HLL (flag set via extop on HLL
side).

This change is being made to coincide with a Rakudo development
regarding statevar initialization.

See [RT#102994](https://rt.perl.org/Public/Bug/Display.html?id=102994)