### PR TITLE
Rakudo Issue 1622: Fix bug with iteration of empty character class

### DIFF
--- a/src/QRegex/P6Regex/Actions.nqp
+++ b/src/QRegex/P6Regex/Actions.nqp
@@ -765,8 +765,8 @@ class QRegex::P6Regex::Actions is HLL::Actions {
             @alts.push(QAST::Regex.new( $str, :rxtype<enumcharlist>, :node($/), :negate( $<sign> eq '-' ),
                                         :subtype($RXm ?? 'ignoremark' !! '') ))
                 if nqp::chars($str);
-            $qast := +@alts == 1 ?? @alts[0] !!
-                $<sign> eq '-' ??
+            $qast := ( my $num := +@alts ) == 1 ?? @alts[0] !!
+                0 < $num && $<sign> eq '-' ??
                     QAST::Regex.new( :rxtype<concat>, :node($/), :negate(1),
                         QAST::Regex.new( :rxtype<conj>, :subtype<zerowidth>, |@alts ),
                         QAST::Regex.new( :rxtype<cclass>, :name<.> ) ) !!


### PR DESCRIPTION
Check that there is at least one character class before applying the
regex nodes.

When compiling the 'conj' regex node, it expects to be able to shift
off at least one child node and iterates past the end as a result.

Fixes [Rakudo Issue #1622](https://github.com/rakudo/rakudo/issues/1622)