### PR TITLE
[RFC] Panic when given empty character class <[ ]>

### DIFF
--- a/src/QRegex/P6Regex/Actions.nqp
+++ b/src/QRegex/P6Regex/Actions.nqp
@@ -772,6 +772,13 @@ class QRegex::P6Regex::Actions is HLL::Actions {
                         QAST::Regex.new( :rxtype<cclass>, :name<.> ) ) !!
                     QAST::Regex.new( :rxtype<alt>, |@alts );
         }
+
+        if $qast.rxtype ne 'cclass' && +@($qast) == 0 {
+            $/.panic('Cannot have an empty character class. If you intended to include '
+                ~ 'whitespace within this character class, escape it with \\'
+            );
+        }
+
         make $qast;
     }
 


### PR DESCRIPTION
Description: 
Check whether the QAST node has any children to determine if it is
empty.  The exception are the backslash cclass nodes (\b, \n, \s, etc).

When providing a fix for [Rakudo Issue 1622](https://github.com/rakudo/rakudo/issues/1622), there was some discussion about whether the empty character class should be allowed at all ([see discussion here](https://github.com/perl6/nqp/pull/432)).

Should this panic behavior be adopted as part of the official behavior of Perl 6 in future releases (6.d+) despite it being somewhat at odds with the behavior detailed in the roast before? 