### PR TITLE
Expose 'slice' op in NQP (MoarVM / JVM/ JS)

### DIFF
--- a/docs/ops.markdown
+++ b/docs/ops.markdown
@@ -781,9 +781,19 @@ to.
 * `slice(@arr, int $start_pos, int $end_pos --> @copy)`
 
 Copy the elements in `@arr` starting at `$start_pos` and ending at `$end_pos`
-and return the resulting list.  If `$start_pos` is a negative value, the start
-value is set to position 0. If `$end_pos` is a negative value, the end value is
-set to the position of the last element in the list.
+and return the resulting list. If `$start_pos` or `$end_pos` is ```-n``` it will
+translate into the ```n```th position relative to the end of the list.
+
+```perl6
+
+my @a := 'a', 'b', 'c';
+print($_ ~ ', ') for nqp::slice(@a, 0, -2);
+
+# OUTPUT: «a, b»
+```
+
+Will throw an exception if either `$start_pos` or `$end_pos` is out-of-bounds
+(after translation).
 
 ## splice
 * `splice(@arr, @from, int $offset, int $count --> @arr)`

--- a/docs/ops.markdown
+++ b/docs/ops.markdown
@@ -65,6 +65,7 @@
   * [pop](#pop)
   * [setelems](#setelems)
   * [shift](#shift)
+  * [slice](#slice)
   * [splice](#splice)
   * [unshift](#unshift)
   * [iterator](#iterator)
@@ -775,6 +776,14 @@ elements at the end are bound with potentially VM specific null entries.
 Return the value of @arr at index 0, unbind @arr at index 0, and move all
 other bindings of @arr to the index one below what they were previously bound
 to.
+
+## slice
+* `slice(@arr, int $start_pos, int $end_pos --> @copy)`
+
+Copy the elements in `@arr` starting at `$start_pos` and ending at `$end_pos`
+and return the resulting list.  If `$start_pos` is a negative value, the start
+value is set to position 0. If `$end_pos` is a negative value, the end value is
+set to the position of the last element in the list.
 
 ## splice
 * `splice(@arr, @from, int $offset, int $count --> @arr)`

--- a/src/vm/js/Operations.nqp
+++ b/src/vm/js/Operations.nqp
@@ -943,6 +943,8 @@ class QAST::OperationsJS {
         }
     });
 
+    add_simple_op('slice', $T_OBJ, [$T_OBJ, $T_INT, $T_INT], :method_call, :side_effects);
+
     add_simple_op('splice', $T_OBJ, [$T_OBJ, $T_OBJ, $T_INT, $T_INT],
         :method_call, :side_effects);
 

--- a/src/vm/js/nqp-runtime/reprs.js
+++ b/src/vm/js/nqp-runtime/reprs.js
@@ -1157,6 +1157,20 @@ class VMArray extends REPR {
         return this.array.length;
       }
 
+      $$slice(start, end) {
+        start = start < 0 ? this.array.length + start : start;
+        end   = end   < 0 ? this.array.length + end   : end;
+        if ( end < start || start < 0 || end < 0
+             || this.array.length <= start || this.array.length <= end )
+        {
+            throw new NQPException('VMArray: Slice index out of bounds');
+        }
+
+        const dest = new STable.ObjConstructor();
+        dest.array = this.array.slice(start, end + 1);
+        return dest;
+      }
+
       $$splice(source, offset, count) {
         const removing = this.array.length - offset > count ? count : this.array.length - offset;
         // TODO think about the case when the source is not VMArray
@@ -2058,6 +2072,10 @@ class MultiDimArray extends REPR {
 
       $$push(value) {
         throw new NQPException('Cannot push a fixed dimension array');
+      }
+
+      $$slice(start, end) {
+        throw new NQPException('Cannot slice a multidim array');
       }
 
       $$splice(source, offset, length) {

--- a/src/vm/jvm/QAST/Compiler.nqp
+++ b/src/vm/jvm/QAST/Compiler.nqp
@@ -2567,6 +2567,7 @@ QAST::OperationsJAST.map_classlib_core_op('shift', $TYPE_OPS, 'shift', [$RT_OBJ]
 QAST::OperationsJAST.map_classlib_core_op('shift_i', $TYPE_OPS, 'shift_i', [$RT_OBJ], $RT_INT, :tc);
 QAST::OperationsJAST.map_classlib_core_op('shift_n', $TYPE_OPS, 'shift_n', [$RT_OBJ], $RT_NUM, :tc);
 QAST::OperationsJAST.map_classlib_core_op('shift_s', $TYPE_OPS, 'shift_s', [$RT_OBJ], $RT_STR, :tc);
+QAST::OperationsJAST.map_classlib_core_op('slice', $TYPE_OPS, 'slice', [$RT_OBJ, $RT_INT, $RT_INT], $RT_OBJ, :tc);
 QAST::OperationsJAST.map_classlib_core_op('splice', $TYPE_OPS, 'splice', [$RT_OBJ, $RT_OBJ, $RT_INT, $RT_INT], $RT_OBJ, :tc);
 QAST::OperationsJAST.map_classlib_core_op('isint', $TYPE_OPS, 'isint', [$RT_OBJ], $RT_INT, :tc);
 QAST::OperationsJAST.map_classlib_core_op('isnum', $TYPE_OPS, 'isnum', [$RT_OBJ], $RT_INT, :tc);

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
@@ -3157,6 +3157,10 @@ public final class Ops {
             throw ExceptionHandling.dieInternal(tc, "This is not a native str array");
         return tc.native_s;
     }
+    public static SixModelObject slice(SixModelObject arr, long start, long end, ThreadContext tc) {
+        SixModelObject dest = arr.st.REPR.allocate(tc, arr.st);
+        return arr.slice(tc, dest, start, end);
+    }
     public static SixModelObject splice(SixModelObject arr, SixModelObject from, long offset, long count, ThreadContext tc) {
         arr.splice(tc, from, offset, count);
         return arr;

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/SixModelObject.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/SixModelObject.java
@@ -121,6 +121,9 @@ public abstract class SixModelObject implements Cloneable {
     public void shift_native(ThreadContext tc) {
         throw ExceptionHandling.dieInternal(tc, this.st.REPR.name + " representation does not implement shift_native");
     }
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
+        throw ExceptionHandling.dieInternal(tc, this.st.REPR.name + " representation does not implement slice");
+    }
     public void splice(ThreadContext tc, SixModelObject from, long offset, long count) {
         throw ExceptionHandling.dieInternal(tc, this.st.REPR.name + " representation does not implement splice");
     }

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/TypeObject.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/TypeObject.java
@@ -54,6 +54,9 @@ public class TypeObject extends SixModelObject {
     public SixModelObject shift_boxed(ThreadContext tc) {
         throw ExceptionHandling.dieInternal(tc, "Cannot do aggregate operation on a type object");
     }
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
+        throw ExceptionHandling.dieInternal(tc, "Cannot do aggregate operation on a type object");
+    }
     public void splice(ThreadContext tc, SixModelObject from, long offset, long count) {
         throw ExceptionHandling.dieInternal(tc, "Cannot do aggregate operation on a type object");
     }

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/MultiDimArrayInstanceBase.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/MultiDimArrayInstanceBase.java
@@ -89,6 +89,9 @@ public abstract class MultiDimArrayInstanceBase extends SixModelObject {
     public void shift_native(ThreadContext tc) {
         throw ExceptionHandling.dieInternal(tc, "Cannot shift a fixed dimension array");
     }
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
+        throw ExceptionHandling.dieInternal(tc, "Cannot slice a multidim array");
+    }
     public void splice(ThreadContext tc, SixModelObject from, long offset, long count) {
         throw ExceptionHandling.dieInternal(tc, "Cannot splice a fixed dimension array");
     }

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/P6OpaqueBaseInstance.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/P6OpaqueBaseInstance.java
@@ -160,6 +160,9 @@ public class P6OpaqueBaseInstance extends SixModelObject {
     public void shift_native(ThreadContext tc) {
         posDelegate().shift_native(tc);
     }
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
+        return posDelegate().slice(tc, dest, start, end);
+    }
     public void splice(ThreadContext tc, SixModelObject from, long offset, long count) {
         posDelegate().splice(tc, from, offset, count);
     }

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/P6OpaqueDelegateInstance.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/P6OpaqueDelegateInstance.java
@@ -61,6 +61,9 @@ public class P6OpaqueDelegateInstance extends P6OpaqueBaseInstance {
     public SixModelObject shift_boxed(ThreadContext tc) {
         return delegate.shift_boxed(tc);
     }
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
+        return delegate.slice(tc, dest, start, end);
+    }
     public void splice(ThreadContext tc, SixModelObject from, long offset, long count) {
         delegate.splice(tc, from, offset, count);
     }

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance.java
@@ -174,6 +174,24 @@ public class VMArrayInstance extends VMArrayInstanceBase {
         return result;
     }
 
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
+        long lastElem = this.elems - 1;
+        if (lastElem < start || lastElem < end || (end < start && 0 <= start && 0 <= end) ) {
+            throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
+        }
+
+        start = 0 <= start ? start : 0;
+        end   = 0 <= end   ? end   : lastElem;
+
+        long numWanted = end - start + 1;
+        if (0 < numWanted) {
+            for (long i = 0; i < numWanted; i++) {
+                dest.bind_pos_boxed(tc, i, this.slots[ (int)(start + i) ]);
+            }
+        }
+        return dest;
+    }
+
     /* This can be optimized for the case we have two VMArray representation objects. */
     public void splice(ThreadContext tc, SixModelObject from, long offset, long count) {
         long elems0 = elems;

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance.java
@@ -175,13 +175,11 @@ public class VMArrayInstance extends VMArrayInstanceBase {
     }
 
     public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
-        long lastElem = this.elems - 1;
-        if (lastElem < start || lastElem < end || (end < start && 0 <= start && 0 <= end) ) {
+        start = start < 0 ? this.elems + start : start;
+        end   = end   < 0 ? this.elems + end   : end;
+        if ( end < start || start < 0 || end < 0 || this.elems <= start || this.elems <= end ) {
             throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
         }
-
-        start = 0 <= start ? start : 0;
-        end   = 0 <= end   ? end   : lastElem;
 
         long numWanted = end - start + 1;
         if (0 < numWanted) {

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_i.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_i.java
@@ -175,13 +175,11 @@ public class VMArrayInstance_i extends VMArrayInstanceBase {
     }
 
     public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
-        long lastElem = this.elems - 1;
-        if (lastElem < start || lastElem < end || (end < start && 0 <= start && 0 <= end) ) {
+        start = start < 0 ? this.elems + start : start;
+        end   = end   < 0 ? this.elems + end   : end;
+        if ( end < start || start < 0 || end < 0 || this.elems <= start || this.elems <= end ) {
             throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
         }
-
-        start = 0 <= start ? start : 0;
-        end   = 0 <= end   ? end   : lastElem;
 
         long numWanted = end - start + 1;
         if (0 < numWanted) {

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_i.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_i.java
@@ -174,6 +174,25 @@ public class VMArrayInstance_i extends VMArrayInstanceBase {
         elems--;
     }
 
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
+        long lastElem = this.elems - 1;
+        if (lastElem < start || lastElem < end || (end < start && 0 <= start && 0 <= end) ) {
+            throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
+        }
+
+        start = 0 <= start ? start : 0;
+        end   = 0 <= end   ? end   : lastElem;
+
+        long numWanted = end - start + 1;
+        if (0 < numWanted) {
+            for (long i = 0; i < numWanted; i++) {
+                this.at_pos_native(tc, start + i);
+                dest.bind_pos_native(tc, i);
+            }
+        }
+        return dest;
+    }
+
     /* This can be optimized for the case we have two VMArray representation objects. */
     public void splice(ThreadContext tc, SixModelObject from, long offset, long count) {
         long elems0 = elems;

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_i16.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_i16.java
@@ -174,6 +174,25 @@ public class VMArrayInstance_i16 extends VMArrayInstanceBase {
         elems--;
     }
 
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
+        long lastElem = this.elems - 1;
+        if (lastElem < start || lastElem < end || (end < start && 0 <= start && 0 <= end) ) {
+            throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
+        }
+
+        start = 0 <= start ? start : 0;
+        end   = 0 <= end   ? end   : lastElem;
+
+        long numWanted = end - start + 1;
+        if (0 < numWanted) {
+            for (long i = 0; i < numWanted; i++) {
+                this.at_pos_native(tc, start + i);
+                dest.bind_pos_native(tc, i);
+            }
+        }
+        return dest;
+    }
+
     /* This can be optimized for the case we have two VMArray representation objects. */
     public void splice(ThreadContext tc, SixModelObject from, long offset, long count) {
         long elems0 = elems;

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_i16.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_i16.java
@@ -175,13 +175,11 @@ public class VMArrayInstance_i16 extends VMArrayInstanceBase {
     }
 
     public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
-        long lastElem = this.elems - 1;
-        if (lastElem < start || lastElem < end || (end < start && 0 <= start && 0 <= end) ) {
+        start = start < 0 ? this.elems + start : start;
+        end   = end   < 0 ? this.elems + end   : end;
+        if ( end < start || start < 0 || end < 0 || this.elems <= start || this.elems <= end ) {
             throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
         }
-
-        start = 0 <= start ? start : 0;
-        end   = 0 <= end   ? end   : lastElem;
 
         long numWanted = end - start + 1;
         if (0 < numWanted) {

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_i32.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_i32.java
@@ -174,6 +174,25 @@ public class VMArrayInstance_i32 extends VMArrayInstanceBase {
         elems--;
     }
 
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
+        long lastElem = this.elems - 1;
+        if (lastElem < start || lastElem < end || (end < start && 0 <= start && 0 <= end) ) {
+            throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
+        }
+
+        start = 0 <= start ? start : 0;
+        end   = 0 <= end   ? end   : lastElem;
+
+        long numWanted = end - start + 1;
+        if (0 < numWanted) {
+            for (long i = 0; i < numWanted; i++) {
+                this.at_pos_native(tc, start + i);
+                dest.bind_pos_native(tc, i);
+            }
+        }
+        return dest;
+    }
+
     /* This can be optimized for the case we have two VMArray representation objects. */
     public void splice(ThreadContext tc, SixModelObject from, long offset, long count) {
         long elems0 = elems;

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_i32.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_i32.java
@@ -175,13 +175,11 @@ public class VMArrayInstance_i32 extends VMArrayInstanceBase {
     }
 
     public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
-        long lastElem = this.elems - 1;
-        if (lastElem < start || lastElem < end || (end < start && 0 <= start && 0 <= end) ) {
+        start = start < 0 ? this.elems + start : start;
+        end   = end   < 0 ? this.elems + end   : end;
+        if ( end < start || start < 0 || end < 0 || this.elems <= start || this.elems <= end ) {
             throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
         }
-
-        start = 0 <= start ? start : 0;
-        end   = 0 <= end   ? end   : lastElem;
 
         long numWanted = end - start + 1;
         if (0 < numWanted) {

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_i8.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_i8.java
@@ -174,6 +174,25 @@ public class VMArrayInstance_i8 extends VMArrayInstanceBase {
         elems--;
     }
 
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
+        long lastElem = this.elems - 1;
+        if (lastElem < start || lastElem < end || (end < start && 0 <= start && 0 <= end) ) {
+            throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
+        }
+
+        start = 0 <= start ? start : 0;
+        end   = 0 <= end   ? end   : lastElem;
+
+        long numWanted = end - start + 1;
+        if (0 < numWanted) {
+            for (long i = 0; i < numWanted; i++) {
+                this.at_pos_native(tc, start + i);
+                dest.bind_pos_native(tc, i);
+            }
+        }
+        return dest;
+    }
+
     /* This can be optimized for the case we have two VMArray representation objects. */
     public void splice(ThreadContext tc, SixModelObject from, long offset, long count) {
         long elems0 = elems;

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_i8.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_i8.java
@@ -175,13 +175,11 @@ public class VMArrayInstance_i8 extends VMArrayInstanceBase {
     }
 
     public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
-        long lastElem = this.elems - 1;
-        if (lastElem < start || lastElem < end || (end < start && 0 <= start && 0 <= end) ) {
+        start = start < 0 ? this.elems + start : start;
+        end   = end   < 0 ? this.elems + end   : end;
+        if ( end < start || start < 0 || end < 0 || this.elems <= start || this.elems <= end ) {
             throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
         }
-
-        start = 0 <= start ? start : 0;
-        end   = 0 <= end   ? end   : lastElem;
 
         long numWanted = end - start + 1;
         if (0 < numWanted) {

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_n.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_n.java
@@ -175,13 +175,11 @@ public class VMArrayInstance_n extends VMArrayInstanceBase {
     }
 
     public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
-        long lastElem = this.elems - 1;
-        if (lastElem < start || lastElem < end || (end < start && 0 <= start && 0 <= end) ) {
+        start = start < 0 ? this.elems + start : start;
+        end   = end   < 0 ? this.elems + end   : end;
+        if ( end < start || start < 0 || end < 0 || this.elems <= start || this.elems <= end ) {
             throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
         }
-
-        start = 0 <= start ? start : 0;
-        end   = 0 <= end   ? end   : lastElem;
 
         long numWanted = end - start + 1;
         if (0 < numWanted) {

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_n.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_n.java
@@ -174,6 +174,25 @@ public class VMArrayInstance_n extends VMArrayInstanceBase {
         elems--;
     }
 
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
+        long lastElem = this.elems - 1;
+        if (lastElem < start || lastElem < end || (end < start && 0 <= start && 0 <= end) ) {
+            throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
+        }
+
+        start = 0 <= start ? start : 0;
+        end   = 0 <= end   ? end   : lastElem;
+
+        long numWanted = end - start + 1;
+        if (0 < numWanted) {
+            for (long i = 0; i < numWanted; i++) {
+                this.at_pos_native(tc, start + i);
+                dest.bind_pos_native(tc, i);
+            }
+        }
+        return dest;
+    }
+
     /* This can be optimized for the case we have two VMArray representation objects. */
     public void splice(ThreadContext tc, SixModelObject from, long offset, long count) {
         long elems0 = elems;

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_s.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_s.java
@@ -175,13 +175,11 @@ public class VMArrayInstance_s extends VMArrayInstanceBase {
     }
 
     public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
-        long lastElem = this.elems - 1;
-        if (lastElem < start || lastElem < end || (end < start && 0 <= start && 0 <= end) ) {
+        start = start < 0 ? this.elems + start : start;
+        end   = end   < 0 ? this.elems + end   : end;
+        if ( end < start || start < 0 || end < 0 || this.elems <= start || this.elems <= end ) {
             throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
         }
-
-        start = 0 <= start ? start : 0;
-        end   = 0 <= end   ? end   : lastElem;
 
         long numWanted = end - start + 1;
         if (0 < numWanted) {

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_s.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_s.java
@@ -174,6 +174,25 @@ public class VMArrayInstance_s extends VMArrayInstanceBase {
         elems--;
     }
 
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
+        long lastElem = this.elems - 1;
+        if (lastElem < start || lastElem < end || (end < start && 0 <= start && 0 <= end) ) {
+            throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
+        }
+
+        start = 0 <= start ? start : 0;
+        end   = 0 <= end   ? end   : lastElem;
+
+        long numWanted = end - start + 1;
+        if (0 < numWanted) {
+            for (long i = 0; i < numWanted; i++) {
+                this.at_pos_native(tc, start + i);
+                dest.bind_pos_native(tc, i);
+            }
+        }
+        return dest;
+    }
+
     /* This can be optimized for the case we have two VMArray representation objects. */
     public void splice(ThreadContext tc, SixModelObject from, long offset, long count) {
         long elems0 = elems;

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_u16.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_u16.java
@@ -179,13 +179,11 @@ public class VMArrayInstance_u16 extends VMArrayInstanceBase {
     }
 
     public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
-        long lastElem = this.elems - 1;
-        if (lastElem < start || lastElem < end || (end < start && 0 <= start && 0 <= end) ) {
+        start = start < 0 ? this.elems + start : start;
+        end   = end   < 0 ? this.elems + end   : end;
+        if ( end < start || start < 0 || end < 0 || this.elems <= start || this.elems <= end ) {
             throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
         }
-
-        start = 0 <= start ? start : 0;
-        end   = 0 <= end   ? end   : lastElem;
 
         long numWanted = end - start + 1;
         if (0 < numWanted) {

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_u16.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_u16.java
@@ -178,6 +178,25 @@ public class VMArrayInstance_u16 extends VMArrayInstanceBase {
         elems--;
     }
 
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
+        long lastElem = this.elems - 1;
+        if (lastElem < start || lastElem < end || (end < start && 0 <= start && 0 <= end) ) {
+            throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
+        }
+
+        start = 0 <= start ? start : 0;
+        end   = 0 <= end   ? end   : lastElem;
+
+        long numWanted = end - start + 1;
+        if (0 < numWanted) {
+            for (long i = 0; i < numWanted; i++) {
+                this.at_pos_native(tc, start + i);
+                dest.bind_pos_native(tc, i);
+            }
+        }
+        return dest;
+    }
+
     /* This can be optimized for the case we have two VMArray representation objects. */
     public void splice(ThreadContext tc, SixModelObject from, long offset, long count) {
         long elems0 = elems;

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_u32.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_u32.java
@@ -179,13 +179,11 @@ public class VMArrayInstance_u32 extends VMArrayInstanceBase {
     }
 
     public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
-        long lastElem = this.elems - 1;
-        if (lastElem < start || lastElem < end || (end < start && 0 <= start && 0 <= end) ) {
+        start = start < 0 ? this.elems + start : start;
+        end   = end   < 0 ? this.elems + end   : end;
+        if ( end < start || start < 0 || end < 0 || this.elems <= start || this.elems <= end ) {
             throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
         }
-
-        start = 0 <= start ? start : 0;
-        end   = 0 <= end   ? end   : lastElem;
 
         long numWanted = end - start + 1;
         if (0 < numWanted) {

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_u32.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_u32.java
@@ -178,6 +178,25 @@ public class VMArrayInstance_u32 extends VMArrayInstanceBase {
         elems--;
     }
 
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
+        long lastElem = this.elems - 1;
+        if (lastElem < start || lastElem < end || (end < start && 0 <= start && 0 <= end) ) {
+            throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
+        }
+
+        start = 0 <= start ? start : 0;
+        end   = 0 <= end   ? end   : lastElem;
+
+        long numWanted = end - start + 1;
+        if (0 < numWanted) {
+            for (long i = 0; i < numWanted; i++) {
+                this.at_pos_native(tc, start + i);
+                dest.bind_pos_native(tc, i);
+            }
+        }
+        return dest;
+    }
+
     /* This can be optimized for the case we have two VMArray representation objects. */
     public void splice(ThreadContext tc, SixModelObject from, long offset, long count) {
         long elems0 = elems;

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_u8.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_u8.java
@@ -178,6 +178,25 @@ public class VMArrayInstance_u8 extends VMArrayInstanceBase {
         elems--;
     }
 
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
+        long lastElem = this.elems - 1;
+        if (lastElem < start || lastElem < end || (end < start && 0 <= start && 0 <= end) ) {
+            throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
+        }
+
+        start = 0 <= start ? start : 0;
+        end   = 0 <= end   ? end   : lastElem;
+
+        long numWanted = end - start + 1;
+        if (0 < numWanted) {
+            for (long i = 0; i < numWanted; i++) {
+                this.at_pos_native(tc, start + i);
+                dest.bind_pos_native(tc, i);
+            }
+        }
+        return dest;
+    }
+
     /* This can be optimized for the case we have two VMArray representation objects. */
     public void splice(ThreadContext tc, SixModelObject from, long offset, long count) {
         long elems0 = elems;

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_u8.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_u8.java
@@ -179,13 +179,11 @@ public class VMArrayInstance_u8 extends VMArrayInstanceBase {
     }
 
     public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
-        long lastElem = this.elems - 1;
-        if (lastElem < start || lastElem < end || (end < start && 0 <= start && 0 <= end) ) {
+        start = start < 0 ? this.elems + start : start;
+        end   = end   < 0 ? this.elems + end   : end;
+        if ( end < start || start < 0 || end < 0 || this.elems <= start || this.elems <= end ) {
             throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
         }
-
-        start = 0 <= start ? start : 0;
-        end   = 0 <= end   ? end   : lastElem;
 
         long numWanted = end - start + 1;
         if (0 < numWanted) {

--- a/src/vm/moar/QAST/QASTOperationsMAST.nqp
+++ b/src/vm/moar/QAST/QASTOperationsMAST.nqp
@@ -2542,6 +2542,7 @@ QAST::MASTOperations.add_core_moarop_mapping('shift_i', 'shift_i');
 QAST::MASTOperations.add_core_moarop_mapping('shift_n', 'shift_n');
 QAST::MASTOperations.add_core_moarop_mapping('shift_s', 'shift_s');
 QAST::MASTOperations.add_core_moarop_mapping('splice', 'splice', 0);
+QAST::MASTOperations.add_core_moarop_mapping('slice', 'slice');
 QAST::MASTOperations.add_core_moarop_mapping('isint', 'isint', :decont(0));
 QAST::MASTOperations.add_core_moarop_mapping('isnum', 'isnum', :decont(0));
 QAST::MASTOperations.add_core_moarop_mapping('isstr', 'isstr', :decont(0));

--- a/t/nqp/059-nqpop.t
+++ b/t/nqp/059-nqpop.t
@@ -2,7 +2,7 @@
 
 # Test nqp::op pseudo-functions.
 
-plan(353);
+plan(365);
 
 ok( nqp::add_i(5,2) == 7, 'nqp::add_i');
 ok( nqp::sub_i(5,2) == 3, 'nqp::sub_i');

--- a/t/nqp/059-nqpop.t
+++ b/t/nqp/059-nqpop.t
@@ -2,7 +2,7 @@
 
 # Test nqp::op pseudo-functions.
 
-plan(365);
+plan(371);
 
 ok( nqp::add_i(5,2) == 7, 'nqp::add_i');
 ok( nqp::sub_i(5,2) == 3, 'nqp::sub_i');
@@ -616,19 +616,25 @@ is(nqp::codes(nqp::chr(0x10426) ~ nqp::chr(0x10427)), 2, 'nqp::codes with chars 
     };
 
     is( &to-str( nqp::slice(@l,  2,  3  )), '2,3', 'nqp::slice some values' );
-    is( &to-str( nqp::slice(@l, -1,  3  )), '0,1,2,3', 'nqp::slice from beginning');
+    is( &to-str( nqp::slice(@l, -3, -2  )), '2,3', 'nqp::slice some values relative to end' );
+    is( &to-str( nqp::slice(@l,  2, -2  )), '2,3', 'nqp::slice some values relative to end (mixed)');
+    is( &to-str( nqp::slice(@l,  0,  3  )), '0,1,2,3', 'nqp::slice from beginning');
     is( &to-str( nqp::slice(@l,  2, -1  )), '2,3,4', 'nqp::slice until end');
-    is( &to-str( nqp::slice(@l, -1, -1  )), '0,1,2,3,4', 'nqp::slice from beginning until end');
-    is( &to-str( nqp::slice(@l, -3, -19 )), '0,1,2,3,4', 'nqp::slice from beginning until end; arbitrary negative values');
+    is( &to-str( nqp::slice(@l,  0, -1  )), '0,1,2,3,4', 'nqp::slice from beginning until end');
     is( &to-str( nqp::slice(@l,  2,  2  )), '2', 'nqp::slice one elem');
+    is( &to-str( nqp::slice(@l,  2, -3  )), '2', 'nqp::slice one elem (mixed)');
     is( &to-str( nqp::slice(@l,  0,  0  )), '0', 'nqp::slice one elem at beginning');
-    is( &to-str( nqp::slice(@l, +@l - 1, +@l - 1)), '4', 'nqp::slice one elem at end');
+    is( &to-str( nqp::slice(@l, -1, -1  )), '4', 'nqp::slice one elem at end');
 
     # Test slice exceptions
-    for (3, 2, 'nqp::slice dies; start pos greater than end pos'),
-        (8, 2, 'nqp::slice dies; start pos out of bounds'),
-        (2, 8, 'nqp::slice dies; end pos out of bounds'),
-        (8, 8, 'nqp::slice dies; both out of bounds')
+    for ( 3,   2, 'nqp::slice dies; start pos greater than end pos'),
+        ( 8,   2, 'nqp::slice dies; start pos out of bounds'),
+        ( 2,   8, 'nqp::slice dies; end pos out of bounds'),
+        (-2,  -3, 'nqp::slice dies; start pos greater than end pos (relative to end)'),
+        (-8,   2, 'nqp::slice dies; start pos out of bounds (relative to end)'),
+        ( 2,  -8, 'nqp::slice dies; end pos out of bounds (relative to end)'),
+        (-8,   8, 'nqp::slice dies; both out of bounds'),
+        ( 2, +@l, 'nqp::slice dies; using ".elems" is out of bounds')
     {
         my $start := $_.shift;
         my $end   := $_.shift;


### PR DESCRIPTION
Exposes a lower-level means of taking positional slices.

    slice(@arr, int $start_elem, int $end_elem --> @copy)

Requires this [MoarVM PR](https://github.com/MoarVM/MoarVM/pull/843)