### PR TITLE
[jvm] Add getppid op and upgrade to jdk9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ addons:
     - gcc-6
 
 script:
-    - if [[ $TRAVIS_OS_NAME != osx && $NQP_OPTIONS =~ jvm ]]; then sudo -E apt-get install oracle-java9-installer; fi
+    - if [[ $TRAVIS_OS_NAME != osx && $NQP_OPTIONS =~ jvm ]]; then sudo -E apt-get install openjdk-9-jdk; fi
     - perl Configure.pl $NQP_OPTIONS
     - make test
     - make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,30 @@
-language: "java"
-    
+language: perl
+
+os:
+    - linux
+    - osx
+
 sudo: false
-dist: trusty
+
+fast_finish: true
 
 install: "echo"
-#install: travis_wait 30 mvn install
+dist: trusty
 
-#script: "perl Configure.pl $NQP_OPTIONS; make test"
-script: 
+addons:
+  apt:
+    sources:
+    # add PPAs with more up-to-date toolchains
+    - ubuntu-toolchain-r-test
+    packages:
+    # install toolchains
+    - gcc-6
+
+script:
+    - if [[ $TRAVIS_OS_NAME != osx && $NQP_OPTIONS =~ jvm ]]; then sudo -E apt-get install oracle-java9-installer; fi
     - perl Configure.pl $NQP_OPTIONS
-    - make
-    - travis_wait 30 make test
+    - make test
+    - make install
 
 branches:
    only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,10 @@
-language: perl
-
-os:
-    - linux
-    - osx
+language: java
 
 sudo: false
-
 fast_finish: true
-
 install: "echo"
 dist: trusty
+jdk: oraclejdk9
 
 addons:
   apt:
@@ -19,9 +14,9 @@ addons:
     packages:
     # install toolchains
     - gcc-6
+    - oracle-java9-installer
 
 script:
-    - if [[ $TRAVIS_OS_NAME != osx && $NQP_OPTIONS =~ jvm ]]; then sudo -E apt-get install openjdk-9-jdk; fi
     - perl Configure.pl $NQP_OPTIONS
     - make test
     - make install

--- a/src/vm/jvm/QAST/Compiler.nqp
+++ b/src/vm/jvm/QAST/Compiler.nqp
@@ -2816,6 +2816,7 @@ QAST::OperationsJAST.map_classlib_core_op('exit', $TYPE_OPS, 'exit', [$RT_INT], 
 QAST::OperationsJAST.map_classlib_core_op('sleep', $TYPE_OPS, 'sleep', [$RT_NUM], $RT_NUM);
 QAST::OperationsJAST.map_classlib_core_op('getenvhash', $TYPE_OPS, 'getenvhash', [], $RT_OBJ, :tc);
 QAST::OperationsJAST.map_classlib_core_op('getpid', $TYPE_OPS, 'getpid', [], $RT_INT, :tc);
+QAST::OperationsJAST.map_classlib_core_op('getppid', $TYPE_OPS, 'getppid', [], $RT_INT, :tc);
 QAST::OperationsJAST.map_classlib_core_op('jvmgetproperties', $TYPE_OPS, 'jvmgetproperties', [], $RT_OBJ, :tc);
 QAST::OperationsJAST.map_classlib_core_op('getrusage', $TYPE_OPS, 'getrusage', [$RT_OBJ], $RT_OBJ, :tc);
 

--- a/src/vm/jvm/runtime/org/perl6/nqp/io/AsyncProcessHandle.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/io/AsyncProcessHandle.java
@@ -4,6 +4,7 @@ import com.sun.jna.*;
 import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.ProcessHandle;
 import java.lang.ProcessBuilder;
 import java.lang.ProcessBuilder.Redirect;
 import java.lang.reflect.Field;
@@ -244,26 +245,10 @@ public class AsyncProcessHandle implements IIOClosable {
         public int GetProcessId(Long hProcess);
     }
 
-    /* not tested on windows; taken from https://stackoverflow.com/a/6032734 */
     private long getPID(Process proc) {
         long result = 0;
         try {
-            String procName = proc.getClass().getName();
-            /* for unix/linux systems */
-            if (procName.equals("java.lang.UNIXProcess")) {
-                Field f = proc.getClass().getDeclaredField("pid");
-                f.setAccessible(true);
-                result = f.getLong(proc);
-                f.setAccessible(false);
-            }
-            /* for windows */
-            else if (procName.equals("java.lang.Win32Process") ||
-                     procName.equals("java.lang.ProcessImpl")) {
-                Field f = proc.getClass().getDeclaredField("handle");
-                f.setAccessible(true);
-                result = Kernel32.INSTANCE.GetProcessId((Long)f.get(proc));
-                f.setAccessible(false);
-            }
+            result = proc.toHandle().pid();
         }
         catch (Exception ex) {
             result = 0;

--- a/src/vm/jvm/runtime/org/perl6/nqp/io/SyncProcessHandle.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/io/SyncProcessHandle.java
@@ -9,11 +9,11 @@ import java.nio.charset.Charset;
 import org.perl6.nqp.runtime.ExceptionHandling;
 import org.perl6.nqp.runtime.ThreadContext;
 
-public class ProcessHandle extends SyncHandle {
+public class SyncProcessHandle extends SyncHandle {
 
     public Process process;
 
-    public ProcessHandle(ThreadContext tc) {
+    public SyncProcessHandle(ThreadContext tc) {
         setEncoding(tc, Charset.forName("UTF-8"));
     }
 

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
@@ -11,6 +11,7 @@ import java.lang.invoke.MethodType;
 import java.lang.management.ManagementFactory;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.ProcessHandle;
 import java.lang.ProcessBuilder.Redirect;
 import java.lang.Thread;
 import java.math.BigDecimal;
@@ -68,7 +69,7 @@ import org.perl6.nqp.io.IIOSeekable;
 import org.perl6.nqp.io.IIOSyncReadable;
 import org.perl6.nqp.io.IIOSyncWritable;
 import org.perl6.nqp.io.IIOPossiblyTTY;
-import org.perl6.nqp.io.ProcessHandle;
+import org.perl6.nqp.io.SyncProcessHandle;
 import org.perl6.nqp.io.ProcessChannel;
 import org.perl6.nqp.io.ServerSocketHandle;
 import org.perl6.nqp.io.SocketHandle;
@@ -1077,7 +1078,7 @@ public final class Ops {
     public static SixModelObject syncpipe(ThreadContext tc) {
         SixModelObject IOType = tc.curFrame.codeRef.staticInfo.compUnit.hllConfig.ioType;
         IOHandleInstance h = (IOHandleInstance)IOType.st.REPR.allocate(tc, IOType.st);
-        h.handle = new ProcessHandle(tc);
+        h.handle = new SyncProcessHandle(tc);
         return h;
     }
 
@@ -1146,23 +1147,23 @@ public final class Ops {
         if (in instanceof IOHandleInstance) {
             if ((flags & PIPE_CAPTURE_IN) != 0)
                 /* getOutputStream() returns the output stream connected to the normal input of the subprocess. */
-                ((ProcessHandle)((IOHandleInstance)in).handle).bindChannel(tc, process, process.getOutputStream());
+                ((SyncProcessHandle)((IOHandleInstance)in).handle).bindChannel(tc, process, process.getOutputStream());
 
             if ((flags & PIPE_INHERIT_IN) != 0) {
                 /* If our stdin is connected to an output stream of another process, we need to let it run in a thread. */
                 ProcessChannel pc = new ProcessChannel(process, process.getOutputStream(),
-                    ((ProcessChannel)((ProcessHandle)((IOHandleInstance)in).handle).chan).in);
+                    ((ProcessChannel)((SyncProcessHandle)((IOHandleInstance)in).handle).chan).in);
                 new Thread(pc).start();
             }
         }
 
         if ((flags & PIPE_CAPTURE_OUT) != 0 && out instanceof IOHandleInstance)
             /* getInputStream() returns the input stream connected to the normal output of the subprocess. */
-            ((ProcessHandle)((IOHandleInstance)out).handle).bindChannel(tc, process, process.getInputStream());
+            ((SyncProcessHandle)((IOHandleInstance)out).handle).bindChannel(tc, process, process.getInputStream());
 
         if ((flags & PIPE_CAPTURE_ERR) != 0 && err instanceof IOHandleInstance)
             /* getErrorStream() returns the input stream connected to the error output of the subprocess. */
-            ((ProcessHandle)((IOHandleInstance)err).handle).bindChannel(tc, process, process.getErrorStream());
+            ((SyncProcessHandle)((IOHandleInstance)err).handle).bindChannel(tc, process, process.getErrorStream());
     }
 
     private static long spawn(ThreadContext tc, List<String> args, SixModelObject envObj, String dir,
@@ -5560,17 +5561,21 @@ public final class Ops {
     }
 
     public static long getpid(ThreadContext tc) {
-        /* Questionably portable; see:
-         * http://boxysystems.com/index.php/java-tip-find-process-id-of-running-java-process/
-         */
         try {
-            java.lang.management.RuntimeMXBean runtime = java.lang.management.ManagementFactory.getRuntimeMXBean();
-            Field jvm = runtime.getClass().getDeclaredField("jvm");
-            jvm.setAccessible(true);
-            Object mgmt = jvm.get(runtime);
-            Method pid_method = mgmt.getClass().getDeclaredMethod("getProcessId");
-            pid_method.setAccessible(true);
-            return (Integer)pid_method.invoke(mgmt);
+            ProcessHandle ph = ProcessHandle.current();
+            long res = ph.pid();
+            return res;
+        }
+        catch (Throwable t) {
+            throw ExceptionHandling.dieInternal(tc, t);
+        }
+    }
+
+    public static long getppid(ThreadContext tc) {
+        try {
+            ProcessHandle ph = ProcessHandle.current();
+            long res = ph.parent().get().pid();
+            return res;
         }
         catch (Throwable t) {
             throw ExceptionHandling.dieInternal(tc, t);

--- a/tools/build/Makefile-JVM.in
+++ b/tools/build/Makefile-JVM.in
@@ -121,7 +121,7 @@ j-install: j-all
 
 $(RUNTIME_JAR): $(RUNTIME_JAVAS) tools/build/gen-jvm-properties.pl
 	$(PERL) -MExtUtils::Command -e mkpath bin
-	$(JAVAC) -source 1.8 -cp $(THIRDPARTY_JARS) -g -d bin -encoding UTF8 $(RUNTIME_JAVAS)
+	$(JAVAC) -source 1.9 -cp $(THIRDPARTY_JARS) -g -d bin -encoding UTF8 $(RUNTIME_JAVAS)
 	$(PERL) tools/build/gen-jvm-properties.pl . $(THIRDPARTY_JARS) > jvmconfig.properties
 	$(PERL) tools/build/gen-jvm-properties.pl @prefix@ $(THIRDPARTY_JARS) > bin/jvmconfig.properties
 	$(JAR) cf0 nqp-runtime.jar -C bin/ .


### PR DESCRIPTION
Note: Will require updating the rakudo travis config to use jdk 9 similar to the one included in this PR

JDK 9 adds a new process api:
https://docs.oracle.com/javase/9/docs/api/java/lang/ProcessHandle.html

* Renamed existing `ProcessHandle` class because I wasn't sure how it
would interact with the new java.lang.ProcessHandle.

* Adds `getppid` op on jvm using the new process api.

* Reimplements `getpid` using the new process api.

`ProcessHandle.Info` could probably be used to implement the cpu time instead of `.getOperatingSystemMXBean()`