### PR TITLE
User-defined `ws` should be declarative

### DIFF
--- a/src/QRegex/NFA.nqp
+++ b/src/QRegex/NFA.nqp
@@ -351,10 +351,7 @@ class QRegex::NFA {
             dentout(self.addedge($from, $to, $EDGE_CODEPOINT + $node.negate, 95));
         }
         elsif !$node.negate &&
-                ($node.name eq 'ws' ||
-                    $subtype eq 'method' &&
-                    (nqp::istype($node[0][0], QAST::SVal)
-                      ?? $node[0][0].value !! $node[0][0]) eq 'ws') {
+                $node.name eq 'ws' {
             dentout(self.fate($node, $from, $to));
         }
         elsif !$node.negate && $subtype ne 'zerowidth' &&


### PR DESCRIPTION
BTW, maybe other branches of this method(i.e. `method subrule($node, $from, $to)`) need to be modified. User-defined subrules(method as alias) should be declarative.

This close #443 .