### PR TITLE
s:global/start/beginning/ in JVM slice methods

### DIFF
--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
@@ -3164,9 +3164,9 @@ public final class Ops {
             throw ExceptionHandling.dieInternal(tc, "This is not a native str array");
         return tc.native_s;
     }
-    public static SixModelObject slice(SixModelObject arr, long start, long end, ThreadContext tc) {
+    public static SixModelObject slice(SixModelObject arr, long beginning, long end, ThreadContext tc) {
         SixModelObject dest = arr.st.REPR.allocate(tc, arr.st);
-        return arr.slice(tc, dest, start, end);
+        return arr.slice(tc, dest, beginning, end);
     }
     public static SixModelObject splice(SixModelObject arr, SixModelObject from, long offset, long count, ThreadContext tc) {
         arr.splice(tc, from, offset, count);

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/SixModelObject.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/SixModelObject.java
@@ -121,7 +121,7 @@ public abstract class SixModelObject implements Cloneable {
     public void shift_native(ThreadContext tc) {
         throw ExceptionHandling.dieInternal(tc, this.st.REPR.name + " representation does not implement shift_native");
     }
-    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long beginning, long end) {
         throw ExceptionHandling.dieInternal(tc, this.st.REPR.name + " representation does not implement slice");
     }
     public void splice(ThreadContext tc, SixModelObject from, long offset, long count) {

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/TypeObject.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/TypeObject.java
@@ -54,7 +54,7 @@ public class TypeObject extends SixModelObject {
     public SixModelObject shift_boxed(ThreadContext tc) {
         throw ExceptionHandling.dieInternal(tc, "Cannot do aggregate operation on a type object");
     }
-    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long beginning, long end) {
         throw ExceptionHandling.dieInternal(tc, "Cannot do aggregate operation on a type object");
     }
     public void splice(ThreadContext tc, SixModelObject from, long offset, long count) {

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/MultiDimArrayInstanceBase.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/MultiDimArrayInstanceBase.java
@@ -89,7 +89,7 @@ public abstract class MultiDimArrayInstanceBase extends SixModelObject {
     public void shift_native(ThreadContext tc) {
         throw ExceptionHandling.dieInternal(tc, "Cannot shift a fixed dimension array");
     }
-    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long beginning, long end) {
         throw ExceptionHandling.dieInternal(tc, "Cannot slice a multidim array");
     }
     public void splice(ThreadContext tc, SixModelObject from, long offset, long count) {

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/P6OpaqueBaseInstance.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/P6OpaqueBaseInstance.java
@@ -160,8 +160,8 @@ public class P6OpaqueBaseInstance extends SixModelObject {
     public void shift_native(ThreadContext tc) {
         posDelegate().shift_native(tc);
     }
-    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
-        return posDelegate().slice(tc, dest, start, end);
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long beginning, long end) {
+        return posDelegate().slice(tc, dest, beginning, end);
     }
     public void splice(ThreadContext tc, SixModelObject from, long offset, long count) {
         posDelegate().splice(tc, from, offset, count);

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/P6OpaqueDelegateInstance.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/P6OpaqueDelegateInstance.java
@@ -61,8 +61,8 @@ public class P6OpaqueDelegateInstance extends P6OpaqueBaseInstance {
     public SixModelObject shift_boxed(ThreadContext tc) {
         return delegate.shift_boxed(tc);
     }
-    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
-        return delegate.slice(tc, dest, start, end);
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long beginning, long end) {
+        return delegate.slice(tc, dest, beginning, end);
     }
     public void splice(ThreadContext tc, SixModelObject from, long offset, long count) {
         delegate.splice(tc, from, offset, count);

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance.java
@@ -174,17 +174,19 @@ public class VMArrayInstance extends VMArrayInstanceBase {
         return result;
     }
 
-    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
-        start = start < 0 ? this.elems + start : start;
-        end   = end   < 0 ? this.elems + end   : end;
-        if ( end < start || start < 0 || end < 0 || this.elems <= start || this.elems <= end ) {
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long beginning, long end) {
+        beginning = beginning < 0 ? this.elems + beginning : beginning;
+        end       = end       < 0 ? this.elems + end       : end;
+        if ( end < beginning || beginning < 0 || end < 0
+             || this.elems <= beginning || this.elems <= end )
+        {
             throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
         }
 
-        long numWanted = end - start + 1;
+        long numWanted = end - beginning + 1;
         if (0 < numWanted) {
             for (long i = 0; i < numWanted; i++) {
-                dest.bind_pos_boxed(tc, i, this.at_pos_boxed(tc, start + i));
+                dest.bind_pos_boxed(tc, i, this.at_pos_boxed(tc, beginning + i));
             }
         }
         return dest;

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_i.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_i.java
@@ -174,17 +174,19 @@ public class VMArrayInstance_i extends VMArrayInstanceBase {
         elems--;
     }
 
-    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
-        start = start < 0 ? this.elems + start : start;
-        end   = end   < 0 ? this.elems + end   : end;
-        if ( end < start || start < 0 || end < 0 || this.elems <= start || this.elems <= end ) {
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long beginning, long end) {
+        beginning = beginning < 0 ? this.elems + beginning : beginning;
+        end       = end       < 0 ? this.elems + end       : end;
+        if ( end < beginning || beginning < 0 || end < 0
+             || this.elems <= beginning || this.elems <= end )
+        {
             throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
         }
 
-        long numWanted = end - start + 1;
+        long numWanted = end - beginning + 1;
         if (0 < numWanted) {
             for (long i = 0; i < numWanted; i++) {
-                this.at_pos_native(tc, start + i);
+                this.at_pos_native(tc, beginning + i);
                 dest.bind_pos_native(tc, i);
             }
         }

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_i16.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_i16.java
@@ -174,17 +174,19 @@ public class VMArrayInstance_i16 extends VMArrayInstanceBase {
         elems--;
     }
 
-    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
-        start = start < 0 ? this.elems + start : start;
-        end   = end   < 0 ? this.elems + end   : end;
-        if ( end < start || start < 0 || end < 0 || this.elems <= start || this.elems <= end ) {
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long beginning, long end) {
+        beginning = beginning < 0 ? this.elems + beginning : beginning;
+        end       = end       < 0 ? this.elems + end       : end;
+        if ( end < beginning || beginning < 0 || end < 0
+             || this.elems <= beginning || this.elems <= end )
+        {
             throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
         }
 
-        long numWanted = end - start + 1;
+        long numWanted = end - beginning + 1;
         if (0 < numWanted) {
             for (long i = 0; i < numWanted; i++) {
-                this.at_pos_native(tc, start + i);
+                this.at_pos_native(tc, beginning + i);
                 dest.bind_pos_native(tc, i);
             }
         }

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_i32.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_i32.java
@@ -174,17 +174,19 @@ public class VMArrayInstance_i32 extends VMArrayInstanceBase {
         elems--;
     }
 
-    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
-        start = start < 0 ? this.elems + start : start;
-        end   = end   < 0 ? this.elems + end   : end;
-        if ( end < start || start < 0 || end < 0 || this.elems <= start || this.elems <= end ) {
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long beginning, long end) {
+        beginning = beginning < 0 ? this.elems + beginning : beginning;
+        end       = end       < 0 ? this.elems + end       : end;
+        if ( end < beginning || beginning < 0 || end < 0
+             || this.elems <= beginning || this.elems <= end )
+        {
             throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
         }
 
-        long numWanted = end - start + 1;
+        long numWanted = end - beginning + 1;
         if (0 < numWanted) {
             for (long i = 0; i < numWanted; i++) {
-                this.at_pos_native(tc, start + i);
+                this.at_pos_native(tc, beginning + i);
                 dest.bind_pos_native(tc, i);
             }
         }

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_i8.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_i8.java
@@ -174,17 +174,19 @@ public class VMArrayInstance_i8 extends VMArrayInstanceBase {
         elems--;
     }
 
-    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
-        start = start < 0 ? this.elems + start : start;
-        end   = end   < 0 ? this.elems + end   : end;
-        if ( end < start || start < 0 || end < 0 || this.elems <= start || this.elems <= end ) {
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long beginning, long end) {
+        beginning = beginning < 0 ? this.elems + beginning : beginning;
+        end       = end       < 0 ? this.elems + end       : end;
+        if ( end < beginning || beginning < 0 || end < 0
+             || this.elems <= beginning || this.elems <= end )
+        {
             throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
         }
 
-        long numWanted = end - start + 1;
+        long numWanted = end - beginning + 1;
         if (0 < numWanted) {
             for (long i = 0; i < numWanted; i++) {
-                this.at_pos_native(tc, start + i);
+                this.at_pos_native(tc, beginning + i);
                 dest.bind_pos_native(tc, i);
             }
         }

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_n.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_n.java
@@ -174,17 +174,19 @@ public class VMArrayInstance_n extends VMArrayInstanceBase {
         elems--;
     }
 
-    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
-        start = start < 0 ? this.elems + start : start;
-        end   = end   < 0 ? this.elems + end   : end;
-        if ( end < start || start < 0 || end < 0 || this.elems <= start || this.elems <= end ) {
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long beginning, long end) {
+        beginning = beginning < 0 ? this.elems + beginning : beginning;
+        end       = end       < 0 ? this.elems + end       : end;
+        if ( end < beginning || beginning < 0 || end < 0
+             || this.elems <= beginning || this.elems <= end )
+        {
             throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
         }
 
-        long numWanted = end - start + 1;
+        long numWanted = end - beginning + 1;
         if (0 < numWanted) {
             for (long i = 0; i < numWanted; i++) {
-                this.at_pos_native(tc, start + i);
+                this.at_pos_native(tc, beginning + i);
                 dest.bind_pos_native(tc, i);
             }
         }

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_s.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_s.java
@@ -174,17 +174,19 @@ public class VMArrayInstance_s extends VMArrayInstanceBase {
         elems--;
     }
 
-    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
-        start = start < 0 ? this.elems + start : start;
-        end   = end   < 0 ? this.elems + end   : end;
-        if ( end < start || start < 0 || end < 0 || this.elems <= start || this.elems <= end ) {
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long beginning, long end) {
+        beginning = beginning < 0 ? this.elems + beginning : beginning;
+        end       = end       < 0 ? this.elems + end       : end;
+        if ( end < beginning || beginning < 0 || end < 0
+             || this.elems <= beginning || this.elems <= end )
+        {
             throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
         }
 
-        long numWanted = end - start + 1;
+        long numWanted = end - beginning + 1;
         if (0 < numWanted) {
             for (long i = 0; i < numWanted; i++) {
-                this.at_pos_native(tc, start + i);
+                this.at_pos_native(tc, beginning + i);
                 dest.bind_pos_native(tc, i);
             }
         }

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_u16.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_u16.java
@@ -178,17 +178,19 @@ public class VMArrayInstance_u16 extends VMArrayInstanceBase {
         elems--;
     }
 
-    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
-        start = start < 0 ? this.elems + start : start;
-        end   = end   < 0 ? this.elems + end   : end;
-        if ( end < start || start < 0 || end < 0 || this.elems <= start || this.elems <= end ) {
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long beginning, long end) {
+        beginning = beginning < 0 ? this.elems + beginning : beginning;
+        end       = end       < 0 ? this.elems + end       : end;
+        if ( end < beginning || beginning < 0 || end < 0
+             || this.elems <= beginning || this.elems <= end )
+        {
             throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
         }
 
-        long numWanted = end - start + 1;
+        long numWanted = end - beginning + 1;
         if (0 < numWanted) {
             for (long i = 0; i < numWanted; i++) {
-                this.at_pos_native(tc, start + i);
+                this.at_pos_native(tc, beginning + i);
                 dest.bind_pos_native(tc, i);
             }
         }

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_u32.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_u32.java
@@ -178,17 +178,19 @@ public class VMArrayInstance_u32 extends VMArrayInstanceBase {
         elems--;
     }
 
-    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
-        start = start < 0 ? this.elems + start : start;
-        end   = end   < 0 ? this.elems + end   : end;
-        if ( end < start || start < 0 || end < 0 || this.elems <= start || this.elems <= end ) {
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long beginning, long end) {
+        beginning = beginning < 0 ? this.elems + beginning : beginning;
+        end       = end       < 0 ? this.elems + end       : end;
+        if ( end < beginning || beginning < 0 || end < 0
+             || this.elems <= beginning || this.elems <= end )
+        {
             throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
         }
 
-        long numWanted = end - start + 1;
+        long numWanted = end - beginning + 1;
         if (0 < numWanted) {
             for (long i = 0; i < numWanted; i++) {
-                this.at_pos_native(tc, start + i);
+                this.at_pos_native(tc, beginning + i);
                 dest.bind_pos_native(tc, i);
             }
         }

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_u8.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance_u8.java
@@ -178,17 +178,19 @@ public class VMArrayInstance_u8 extends VMArrayInstanceBase {
         elems--;
     }
 
-    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long start, long end) {
-        start = start < 0 ? this.elems + start : start;
-        end   = end   < 0 ? this.elems + end   : end;
-        if ( end < start || start < 0 || end < 0 || this.elems <= start || this.elems <= end ) {
+    public SixModelObject slice(ThreadContext tc, SixModelObject dest, long beginning, long end) {
+        beginning = beginning < 0 ? this.elems + beginning : beginning;
+        end       = end       < 0 ? this.elems + end       : end;
+        if ( end < beginning || beginning < 0 || end < 0
+             || this.elems <= beginning || this.elems <= end )
+        {
             throw ExceptionHandling.dieInternal(tc, "VMArray: Slice index out of bounds");
         }
 
-        long numWanted = end - start + 1;
+        long numWanted = end - beginning + 1;
         if (0 < numWanted) {
             for (long i = 0; i < numWanted; i++) {
-                this.at_pos_native(tc, start + i);
+                this.at_pos_native(tc, beginning + i);
                 dest.bind_pos_native(tc, i);
             }
         }


### PR DESCRIPTION
'start' is also the name of a member variable in each of these classes,
so changing the name of the parameter in the slice methods to help
avoid confusion in the future.

See the impetus for this change [here](https://github.com/rakudo/rakudo/issues/1838#issuecomment-390346938).

This commit doesn't add or remove any functionality and can safely wait until after the 2018.05 release.
