### PR TITLE
Mryan ast debug

### DIFF
--- a/src/QAST/Children.nqp
+++ b/src/QAST/Children.nqp
@@ -18,12 +18,16 @@ role QAST::Children {
     }
 
     method dump_node_list(int $indent, @onto, @node_list) {
+        # Guide lines are triggered from here - if this is a Block
+        # node, then we request a guide line next to its children
+        my $guide-requested := nqp::istype(self, QAST::Block) ;
+
         for @node_list {
             if nqp::istype($_, QAST::Node) {
-                nqp::push(@onto, $_.dump($indent));
+                nqp::push(@onto, $_.dump($indent, :guide-line($guide-requested) ));
             }
             else {
-                nqp::push(@onto, self.dump_indent_string($indent));
+                nqp::push(@onto, self.dump_indent_string($indent, :guide-line($guide-requested) )) ;
                 nqp::push(@onto, '- ');
                 nqp::istype($_, NQPMu)
                     ?? nqp::push(@onto, '(NQPMu)')

--- a/src/QAST/Children.nqp
+++ b/src/QAST/Children.nqp
@@ -23,7 +23,7 @@ role QAST::Children {
                 nqp::push(@onto, $_.dump($indent));
             }
             else {
-                nqp::push(@onto, nqp::x(' ', $indent));
+                nqp::push(@onto, self.dump_indent_string($indent));
                 nqp::push(@onto, '- ');
                 nqp::istype($_, NQPMu)
                     ?? nqp::push(@onto, '(NQPMu)')
@@ -44,7 +44,7 @@ role QAST::Children {
         my $extra := 0;
         for self.extra_children -> $tag, $nodes {
             if $nodes {
-                nqp::push(@onto, nqp::x(' ', $indent));
+                nqp::push(@onto, self.dump_indent_string($indent));
                 nqp::push(@onto, "[" ~ $tag ~ "]");
                 nqp::push(@onto, "\n");
                 self.dump_node_list($indent+2, @onto, nqp::islist($nodes) ?? $nodes !! [$nodes]);
@@ -53,7 +53,7 @@ role QAST::Children {
         }
 
         if $extra && @!children {
-            nqp::push(@onto, nqp::x(' ', $indent) ~ "[children]\n");
+            nqp::push(@onto, self.dump_indent_string($indent) ~ "[children]\n");
             self.dump_node_list($indent+2, @onto, @!children);
         } else {
             self.dump_node_list($indent, @onto, @!children);

--- a/src/QAST/Children.nqp
+++ b/src/QAST/Children.nqp
@@ -25,7 +25,11 @@ role QAST::Children {
             else {
                 nqp::push(@onto, nqp::x(' ', $indent));
                 nqp::push(@onto, '- ');
-                nqp::push(@onto, nqp::istype($_, NQPMu) ?? '(NQPMu)' !! ~$_);
+                nqp::istype($_, NQPMu)
+                    ?? nqp::push(@onto, '(NQPMu)')
+                    !! $_.HOW.name($_) eq 'Sub' || $_.HOW.name($_) eq 'Regex'
+                        ?? nqp::push(@onto, $_.name)
+                        !! nqp::push(@onto, ~$_ );
                 nqp::push(@onto, "\n");
             }
         }

--- a/src/QAST/Node.nqp
+++ b/src/QAST/Node.nqp
@@ -131,9 +131,9 @@ class QAST::Node {
         nqp::die(self.HOW.name(self) ~ " does not support evaluating unquotes");
     }
 
-    method dump(int $indent = 0) {
+    method dump(int $indent = 0, :$guide-line = 0) {
         my @chunks := [
-            self.dump_indent_string($indent), '- ', self.HOW.name(self)
+            self.dump_indent_string($indent, :$guide-line), '- ', self.HOW.name(self)
         ];
         my $extra := self.dump_extra_node_info();
         if nqp::chars($extra) {
@@ -182,10 +182,12 @@ class QAST::Node {
     my $indent-string := "" ;
     my $indent-length := 0  ;
 
-    method dump_indent_string(int $ind) {
+    method dump_indent_string(int $ind, :$guide-line) {
         if $ind > $indent-length {
             my $diff := $ind - $indent-length ;
-            $indent-string := $indent-string ~ nqp::x(' ', $diff) ;
+            my $extra := $guide-line  ?? '│'   !! ' ';
+            $extra := $extra ~ nqp::x(' ', $diff-1) ;
+            $indent-string := $indent-string ~ $extra ;
             $indent-length := nqp::chars($indent-string)
         }
         elsif $ind < $indent-length {

--- a/src/QAST/Node.nqp
+++ b/src/QAST/Node.nqp
@@ -178,4 +178,21 @@ class QAST::Node {
     method dump_children(int $indent, @onto) { }
 
     method dump_extra_node_info() { '' }
+
+    my $indent-string := "" ;
+    my $indent-length := 0  ;
+
+    method dump_indent_string(int $ind) {
+        if $ind > $indent-length {
+            my $diff := $ind - $indent-length ;
+            $indent-string := $indent-string ~ nqp::x(' ', $diff) ;
+            $indent-length := nqp::chars($indent-string)
+        }
+        elsif $ind < $indent-length {
+            $indent-string := nqp::substr($indent-string, 0, $ind) ;
+            $indent-length := $ind
+        }
+
+        $indent-string
+    }
 }

--- a/src/QAST/Node.nqp
+++ b/src/QAST/Node.nqp
@@ -133,7 +133,7 @@ class QAST::Node {
 
     method dump(int $indent = 0) {
         my @chunks := [
-            nqp::x(' ', $indent), '- ', self.HOW.name(self),
+            self.dump_indent_string($indent), '- ', self.HOW.name(self)
         ];
         my $extra := self.dump_extra_node_info();
         if nqp::chars($extra) {

--- a/src/QAST/VM.nqp
+++ b/src/QAST/VM.nqp
@@ -19,7 +19,7 @@ class QAST::VM is QAST::Node does QAST::Children {
 
     method dump_children(int $indent, @onto) {
         for %!alternatives {
-            nqp::push(@onto, nqp::x(' ', $indent));
+            nqp::push(@onto, self.dump_indent_string($indent));
             nqp::push(@onto, '[');
             nqp::push(@onto, $_.key);
             nqp::push(@onto, "]\n");
@@ -28,7 +28,7 @@ class QAST::VM is QAST::Node does QAST::Children {
                 nqp::push(@onto, $_.value.dump($indent+2));
             }
             else {
-                nqp::push(@onto, nqp::x(' ', $indent+2));
+                nqp::push(@onto, self.dump_indent_string($indent+2));
                 nqp::push(@onto, '- ');
                 if $_.key eq 'loadlibs' {
                     nqp::push(@onto, nqp::join(' ',$_.value));

--- a/tools/0001-Shrink-the-QAST-dump-target-ast-for-Want-nodes.patch
+++ b/tools/0001-Shrink-the-QAST-dump-target-ast-for-Want-nodes.patch
@@ -1,0 +1,75 @@
+From 8db026cf0764d0e651168e17070defb01b5eac40 Mon Sep 17 00:00:00 2001
+From: Martin Ryan <mryan50@fastmail.fm>
+Date: Wed, 23 May 2018 14:24:50 +1000
+Subject: [PATCH] Shrink the QAST dump (--target=ast) for Want nodes
+
+---
+ src/QAST/Want.nqp | 54 ++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 54 insertions(+)
+
+diff --git a/src/QAST/Want.nqp b/src/QAST/Want.nqp
+index 7cf1ec7..7cbe4f5 100644
+--- a/src/QAST/Want.nqp
++++ b/src/QAST/Want.nqp
+@@ -47,4 +47,58 @@ class QAST::Want is QAST::Node does QAST::Children {
+         }
+         $result
+     }
++
++    method dump(int $indent = 0, :$guide-line) {
++        # Start off the same as QAST::Node::dump()
++        my @chunks := [
++            self.dump_indent_string($indent, :$guide-line), '- ', self.HOW.name(self)
++        ];
++        my $extra := self.dump_extra_node_info();
++        if nqp::chars($extra) {
++            nqp::push(@chunks, "($extra)");
++        }
++
++        nqp::push(@chunks, ' ');
++        nqp::push(@chunks, self.dump_annotations);
++
++        # Is this a Want node we can summarize ?
++        my $summary := "" ;
++        my $want_type := '[[unrecognised]]' ;
++        my int $elems := nqp::elems(@(self));
++        $want_type := ~self[1] if $elems == 3 ;
++
++        if ($want_type eq 'Ii' || $want_type eq 'Ss' || $want_type eq 'v') {
++            # Yes it is...
++            $summary := $summary ~ " '$want_type'" ;
++            $summary := $summary ~ "oid [with/out p6sink]" if $want_type eq 'v' ;
++            nqp::push(@chunks, $summary);
++        }
++ 
++        # Back to QAST::Node::Dump code path...
++        if (self.node) {
++            nqp::push(@chunks, ' ');
++            my $escaped_node := nqp::escape(self.node);
++            nqp::push(@chunks, nqp::substr($escaped_node, 0, 50));
++            if (nqp::chars($escaped_node) > 50) {
++                nqp::push(@chunks, "...");
++            }
++        }
++        nqp::push(@chunks, "\n");
++
++        # Dumping Children - do the "trimming" here if its a node we can summarize
++        if ($summary) {
++            if ($want_type eq 'v') {
++                # Only dump the first of the three children
++                nqp::push(@chunks, self[0].dump($indent + 2));
++            }
++            # NOTE If want_type = Ii or Ss, then skip dumping children completely
++        }
++        else {
++            # Dump the children normally - as in QAST::Node::dump
++            self.dump_children($indent + 2, @chunks)
++        }
++    
++        return join('', @chunks);
++    }
++
+ }
+-- 
+2.8.2
+


### PR DESCRIPTION
Hello,

I've been (slowly) working on issue #1858 of the doc repository.  Before documenting it, I need to figure out how to use it.  Along the way, I developed three "QAST debugging aids" for myself, one of which I think *may* be useful generally and is the subject of this pull request.

The first commit fixes a minor bug which I created issue #448 to cover.
The next three commits add "guide lines" to highlight the "reach" of blocks when using --target=ast.  These three commits constitute the "maybe generally useful" debugging aid for you to consider.
The last commit adds a patch file for the second of the debugging aids which supresses the printing of some QAST nodes under QAST::Want nodes.  This is a bit "heavy handed" so I've put it in the tools directory just so those who are curious can apply it (using "git am") and give me any feedback you have.

Finally, I'm happy to take any feedback on a "meta" level on whether I should have suggested any of this..

Regards