### PR TITLE
Fix error in JS Makefile generation (spew)

### DIFF
--- a/tools/build/gen-js-makefile.nqp
+++ b/tools/build/gen-js-makefile.nqp
@@ -227,5 +227,5 @@ rule('js-deps', '',
 deps("js-all", "js-deps", "js-cross", $nqp-bootstrapped);
 
 sub MAIN($program, $output-file) {
-    spew($output-file, $out);
+    spurt($output-file, $out);
 }


### PR DESCRIPTION
The spew sub was changed to spurt to better match Rakudo.