### PR TITLE
Change getsignals output from hash to array 

### DIFF
--- a/docs/ops.markdown
+++ b/docs/ops.markdown
@@ -2481,8 +2481,8 @@ Changing the hash doesn't affect the environment variables
 ## getsignals
 * `getsignals(--> Mu)`
 
-Returns a hash containing signal names mapped to the proper signum integer on
-the host platform (MacOSX, Linux, BSD, etc).
+Returns a list containing signal names interleaved with the associated signum
+integer on the host platform (MacOSX, Linux, BSD, etc).
 
 If the current backend does not support the registering of a signal handler for
 a given signal, the hash value will be a negative integer. For instance, the JVM
@@ -2490,7 +2490,7 @@ only supports signal handlers for SIGINT and SIGKILL, so all the values will be
 negative except 2 (SIGINT) and 9 (SIGKILL). If a signal is not available on the
 host system, the hash value will be set to 0.
 
-The complete list of hash keys is as follows:
+The complete list of signal entries is as follows:
 
     * SIGHUP
     * SIGINT

--- a/src/vm/js/Operations.nqp
+++ b/src/vm/js/Operations.nqp
@@ -533,7 +533,7 @@ class QAST::OperationsJS {
     add_simple_op('chmod', $T_VOID, [$T_STR, $T_INT], :side_effects);
 
     add_simple_op('getenvhash', $T_OBJ, [], :side_effects);
-    add_simple_op('getsignals', $T_OBJ, [], :side_effects);
+    add_simple_op('getsignals', $T_OBJ, [], :side_effects, :takes_hll);
     add_simple_op('cwd', $T_STR, [], :side_effects);
 
 

--- a/src/vm/js/nqp-runtime/io.js
+++ b/src/vm/js/nqp-runtime/io.js
@@ -9,6 +9,8 @@ const Hash = require('./hash.js');
 
 const core = require('./core.js');
 
+const hll = require('./hll.js');
+
 const child_process = require('child_process');
 
 const NQPObject = require('./nqp-object.js');
@@ -548,7 +550,7 @@ op.permit = function(handle, channel, permits) {
 };
 
 let sigCache = null;
-op.getsignals = function() {
+op.getsignals = function(currentHLL) {
   if (sigCache) {
     return sigCache;
   }
@@ -575,10 +577,12 @@ op.getsignals = function() {
     'SIGUSR2', 'SIGTHR',    'SIGSTKFLT', 'SIGPWR',   'SIGBREAK',
   ];
 
-  const res = new Hash();
+  const arr = [];
   for (const k of sigWanted) {
-    res.content.set( k, new NQPInt(k in osSigs ? osSigs[k] : 0) );
+    arr.push( new NQPStr(k), new NQPInt(k in osSigs ? osSigs[k] : 0) );
   }
+
+  const res = hll.slurpyArray(currentHLL, arr);
   sigCache = res;
   return res;
 };

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/IOOps.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/IOOps.java
@@ -49,7 +49,7 @@ public final class IOOps {
         }
         private static final Map<String, Integer> sigSupported = SigSupported.build();
 
-        private static final List<String> sigKeys = Arrays.asList(
+        public static final List<String> sigKeys = Arrays.asList(
             "SIGHUP",  "SIGINT",    "SIGQUIT",   "SIGILL",   "SIGTRAP", "SIGABRT",
             "SIGEMT",  "SIGFPE",    "SIGKILL",   "SIGBUS",   "SIGSEGV", "SIGSYS",
             "SIGPIPE", "SIGALRM",   "SIGTERM",   "SIGURG",   "SIGSTOP", "SIGTSTP",
@@ -132,16 +132,18 @@ public final class IOOps {
     public static SixModelObject getsignals(ThreadContext tc) {
         if (sigCache != null) return sigCache;
 
-        SixModelObject hashType = tc.curFrame.codeRef.staticInfo.compUnit.hllConfig.hashType;
+        SixModelObject listType = tc.curFrame.codeRef.staticInfo.compUnit.hllConfig.listType;
+        SixModelObject strType  = tc.curFrame.codeRef.staticInfo.compUnit.hllConfig.strBoxType;
         SixModelObject intType  = tc.curFrame.codeRef.staticInfo.compUnit.hllConfig.intBoxType;
-        SixModelObject res      = hashType.st.REPR.allocate(tc, hashType.st);
+        SixModelObject res      = listType.st.REPR.allocate(tc, listType.st);
 
         Map<String, Integer> sigWanted = SigProcess.process();
 
-        // Box the hash values for HLL
-        for (String sig : sigWanted.keySet()) {
+        // Box the list values for HLL
+        for (String sig : SigProcess.sigKeys) {
             long signum = (long)sigWanted.get(sig);
-            res.bind_key_boxed( tc, sig, Ops.box_i(signum, intType, tc) );
+            res.push_boxed( tc, Ops.box_s(sig,    strType, tc) );
+            res.push_boxed( tc, Ops.box_i(signum, intType, tc) );
         }
         sigCache = res;
         return res;


### PR DESCRIPTION
This is the NQP component of a whole spanning the MoarVM, NQP,
and Rakudo repos.
[MoarVM](https://github.com/MoarVM/MoarVM/pull/870)
[Rakudo](https://github.com/rakudo/rakudo/pull/1897)

Changed the output of getsignals from a hash to an array with signal
names interleaved with signal values.

The purpose of this is to allow for a more consistent ordering of
signals when exposed to the HLL.