### PR TITLE
[Impl] !~~by adding NOT_ACCEPTS method

### DIFF
--- a/src/NQP/Actions.nqp
+++ b/src/NQP/Actions.nqp
@@ -1674,6 +1674,10 @@ class NQP::Actions is HLL::Actions {
         make QAST::Op.new( :op<callmethod>, :name<ACCEPTS>, :node($/) );
     }
 
+    method infix:sym<!~~>($/) {
+        make QAST::Op.new( :op<callmethod>, :name<NOT_ACCEPTS>, :node($/) );
+    }
+
     # Takes a multi-part name that we know is in a package and generates
     # QAST to look it up using NQP package semantics.
     sub lexical_package_lookup(@name, $/) {

--- a/src/NQP/Grammar.nqp
+++ b/src/NQP/Grammar.nqp
@@ -821,6 +821,7 @@ grammar NQP::Grammar is HLL::Grammar {
     token infix:sym«gt»   { <sym>  <O(|%relational, :op<isgt_s>)> }
     token infix:sym«=:=»  { <sym>  <O(|%relational, :op<eqaddr>)> }
     token infix:sym<~~>   { <sym>  <O(|%relational, :reducecheck<smartmatch>)> }
+    token infix:sym<!~~>  { <sym>  <O(|%relational, :reducecheck<smartmatch>)> }
 
     token infix:sym<&&>   { <sym>  <O(|%tight_and, :op<if>)> }
 

--- a/src/QRegex/Cursor.nqp
+++ b/src/QRegex/Cursor.nqp
@@ -1368,6 +1368,9 @@ class NQPRegexMethod {
     multi method ACCEPTS(NQPRegexMethod:D $self: $target) {
         NQPMatch.parse($target, :rule(self))
     }
+    multi method NOT_ACCEPTS(NQPRegexMethod:D $self: $target) {
+        nqp::isfalse(NQPMatch.parse($target, :rule(self)))
+    }
     method name() {
         nqp::getcodename($!code)
     }
@@ -1380,6 +1383,9 @@ nqp::setinvokespec(NQPRegexMethod, NQPRegexMethod, '$!code', nqp::null);
 class NQPRegex is NQPRegexMethod {
     multi method ACCEPTS(NQPRegex:D $self: $target) {
         NQPMatch.parse($target, :rule(self), :c(0))
+    }
+    multi method NOT_ACCEPTS(NQPRegex:D $self: $target) {
+        nqp::isfalse(NQPMatch.parse($target, :rule(self), :c(0)))
     }
 }
 nqp::setinvokespec(NQPRegex, NQPRegexMethod, '$!code', nqp::null);

--- a/src/core/NQPMu.nqp
+++ b/src/core/NQPMu.nqp
@@ -88,6 +88,11 @@ my class NQPMu {
         nqp::istype($topic, self.WHAT)
     }
 
+    proto method NOT_ACCEPTS($topic) { * }
+    multi method NOT_ACCEPTS(NQPMu:U $self: $topic) {
+        nqp::isfalse(nqp::istype($topic, self.WHAT))
+    }
+
     method isa($type) {
         self.HOW.isa(self, $type)
     }


### PR DESCRIPTION
In fact, I want this PR, like its name, will be NOT_ACCEPTS.

How we achieve this intention at Rakudo is by introduce a metaop logic and negate the result of EXPR.

Right know if we define `!~~` as infix, then we can add ONLY ONE QAST::Node at pos, thus I add a NOT_ACCEPTS method to implement `!~~`

This will close #300 though