### PR TITLE
Modify signals available to getsignals on WIN32

### DIFF
--- a/src/vm/js/nqp-runtime/io.js
+++ b/src/vm/js/nqp-runtime/io.js
@@ -553,19 +553,7 @@ op.getsignals = function() {
     return sigCache;
   }
 
-  const osSigs = (function() {
-    if (os.platform() === 'win32') {
-      // Use same sigs defined for _WIN32 in MoarVM
-      return {
-        SIGHUP:    1,
-        SIGKILL:   9,
-        SIGWINCH: 28,
-      };
-    }
-    else {
-      return os.constants.signals;
-    }
-  })();
+  const osSigs = os.constants.signals;
   const sigWanted = [
     'SIGHUP',  'SIGINT',    'SIGQUIT',   'SIGILL',   'SIGTRAP', 'SIGABRT',
     'SIGEMT',  'SIGFPE',    'SIGKILL',   'SIGBUS',   'SIGSEGV', 'SIGSYS',

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/IOOps.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/IOOps.java
@@ -88,9 +88,16 @@ public final class IOOps {
         }
 
         private static void retrieveValsWin(Map<String, Integer> sigWanted) {
-            // Use same sigs defined for _WIN32 in MoarVM
+            // Use same sigs defined for _WIN32 in MoarVM and in os.constants.signals on NodeJS
             sigWanted.put("SIGHUP",    1);
+            sigWanted.put("SIGINT",    2);
+            sigWanted.put("SIGILL",    4);
+            sigWanted.put("SIGFPE",    8);
             sigWanted.put("SIGKILL",   9);
+            sigWanted.put("SIGSEGV",  11);
+            sigWanted.put("SIGTERM",  15);
+            sigWanted.put("SIGBREAK", 21);
+            sigWanted.put("SIGABRT",  22);
             sigWanted.put("SIGWINCH", 28);
         }
 


### PR DESCRIPTION
JS:
All the signals we need for Windows are actually already defined in
os.constants.signals

JVM:
Match getsignals JVM with MoarVM/JS backends