### PR TITLE
Add callback of nqp::spawnprocasync to catch exception

### DIFF
--- a/src/core/testing.nqp
+++ b/src/core/testing.nqp
@@ -114,6 +114,12 @@ sub run-command($command, :$stdout, :$stderr) {
             ++$read-all2;
         }
     };
+    $config<error> := -> $err {
+      my $ex := nqp::newexception();
+      nqp::setmessage($ex, $err);
+      nqp::setpayload($ex, nqp::null());
+      nqp::throw($ex)
+    }
 
     # define the task
     my $task := nqp::spawnprocasync($queue, $command, nqp::cwd(),


### PR DESCRIPTION
This will fix #467 , which now throw an exception with

  no such file or directory
     at gen/moar/stage2/NQPCORE.setting:1226  (NQPCORE.setting.moarvm:)

instead of hanging.