### PR TITLE
Fix Multiple Statevar Initialization Bugs

### DIFF
--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/CallFrame.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/CallFrame.java
@@ -138,6 +138,7 @@ public class CallFrame implements Cloneable {
             int numoLex = sci.oLexStatic.length;
             this.oLex = new SixModelObject[numoLex];
             for (int i = 0; i < numoLex; i++) {
+                // 0 = static, 1 = clone, 2 = state
                 switch (sci.oLexStaticFlags[i]) {
                 case 0:
                     this.oLex[i] = sci.oLexStatic[i];
@@ -148,6 +149,7 @@ public class CallFrame implements Cloneable {
                 case 2:
                     if (cr.oLexState == null) {
                         cr.oLexState = new SixModelObject[sci.oLexStatic.length];
+                        cr.oLexStateIsHllInit = new boolean[sci.oLexStatic.length];
                         this.stateInit = true;
                     }
                     if (cr.oLexState[i] == null)

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/CallFrame.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/CallFrame.java
@@ -1,5 +1,6 @@
 package org.perl6.nqp.runtime;
 
+import java.util.BitSet;
 import java.util.HashMap;
 
 import org.perl6.nqp.sixmodel.InvocationSpec;
@@ -149,7 +150,7 @@ public class CallFrame implements Cloneable {
                 case 2:
                     if (cr.oLexState == null) {
                         cr.oLexState = new SixModelObject[sci.oLexStatic.length];
-                        cr.oLexStateIsHllInit = new boolean[sci.oLexStatic.length];
+                        cr.oLexStateIsHllInit = new BitSet(sci.oLexStatic.length);
                         this.stateInit = true;
                     }
                     if (cr.oLexState[i] == null)

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/CodeRef.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/CodeRef.java
@@ -39,6 +39,11 @@ public class CodeRef extends SixModelObject {
     public SixModelObject[] oLexState;
 
     /**
+     * Has the given statevar been assigned a value by the HLL?
+     */
+    public boolean[] oLexStateIsHllInit;
+
+    /**
      * The (human-readable) name of the code-ref (not in staticInfo as a
      * number of places want to tweak it per closure clone).
      */

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/CodeRef.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/CodeRef.java
@@ -1,6 +1,8 @@
 package org.perl6.nqp.runtime;
 import java.lang.invoke.MethodHandle;
 
+import java.util.BitSet;
+
 import org.perl6.nqp.sixmodel.SixModelObject;
 
 /**
@@ -41,7 +43,7 @@ public class CodeRef extends SixModelObject {
     /**
      * Has the given statevar been assigned a value by the HLL?
      */
-    public boolean[] oLexStateIsHllInit;
+    public BitSet oLexStateIsHllInit;
 
     /**
      * The (human-readable) name of the code-ref (not in staticInfo as a

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/StaticCodeInfo.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/StaticCodeInfo.java
@@ -55,6 +55,7 @@ public class StaticCodeInfo implements Cloneable {
 
     /**
      * Flags for each static lexical usage.
+     * 0 = static, 1 = clone, 2 = state
      */
     public byte[] oLexStaticFlags;
 


### PR DESCRIPTION
This PR is one part of a series spanning the MoarVM, NQP, and Rakudo repositories.
[MoarVM](https://github.com/MoarVM/MoarVM/pull/916)
[Rakudo]

This series of PRs modifies the state init check to instead keep a record of the statevars that have been 'HLL init-ed' and have that value determine whether to perform the assignment or not. If the statevar is not assigned to on the first invocation, it is shown as needing assignment the next time it is encountered despite what the MVM_FRAME_FLAG_STATE_INIT value is. If the statevar has been assigned to already and is encountered again within the same frame invocation (as the C-style loop example below), it is aware the that assignment has occurred and does not repeat it.

I had submitted a PR similar to this in the past, but this one has been rebased to a much newer HEAD and changed enough to the point that it feels appropriate to open a new PR.

### Specific modifications made are:

* Modified the ```p6stateinit``` extop to take a symbol as an argument. Within the function, lookup that symbol within the frame's lexical registry and determine whether the 'HLL assignment' has taken place. If so, do not assign again.

  * The value that persists whether an 'HLL assignment' has taken place is stored in the CodeRef object (alongside the statevar values themselves), which is unique to each closure. This 'isHllInit' value is a variable-length bit array, with each lexical represented by one bit.

* Added a new extop, ```p6stateinitbulk```, that will take a list of symbols and check multiple in one extop execution (for use in destructuring state assignments)

* Implemented for both the MoarVM and JVM backends.

### Issue being addressed:

In the past, we have determined whether to perform an assignment to a state variable by determining whether or not it was the first invocation of a closure (or clone of a frame). In MoarVM, an MVM_FRAME_FLAG_STATE_INIT value is set on the first frame of a given closure.

This works most of the time, but there are some instances where this is producing undesired results (see [RT #102994](https://rt.perl.org/Public/Bug/Display.html?id=102994))

```perl6
sub f($x) {
    return if $x;
    state $y = 5;
    $y;
} 

f(1);
say f(0);
# OUTPUT:   (Any)
# EXPECTED: 5
```

Since during the first invocation of this closure (when MVM_FRAME_FLAG_STATE_INIT is set) the statevar is not assigned to, on the next invocation the assignment is skipped and the unassigned value (Any) is returned.

In the case of 'once' with a C-style loop conditional (see [GH issue 1684](https://github.com/rakudo/rakudo/issues/1684)), this method also produces some unexpected results.

```perl6
loop (my $i = 0; $i < once { print $i; 10 }; ++$i ) { }
# OUTPUT:   012345678910
# EXPECTED: 0
```

In this case, the 'once' appears in the e2 expression in the C-style loop. The statevar init check occurs within the loop conditional and is executed multiple times within the same initial closure invocation. Because of this, MVM_FRAME_FLAG_STATE_INIT is set and the code within the block (containing print) is executed for each iteration.
