### PR TITLE
Remove some unused JVM interop ops

### DIFF
--- a/docs/ops.markdown
+++ b/docs/ops.markdown
@@ -239,7 +239,6 @@
   * [istrue](#istrue)
   * [istype](#istype)
   * [null](#null)
-  * [jvmisnull `jvm`](#jvmisnull-jvm)
   * [tostr](#tostr)
   * [tonum](#tonum)
   * [unbox](#unbox)
@@ -2050,12 +2049,6 @@ Generate a null value.
 
 The value returned by `null_s` is VM dependant. Notably, it may stringify
 differently depending on the backend.
-
-## jvmisnull `jvm`
-* `jvmisnull(Mu $obj)`
-
-Returns a 1 if the object is an NQP Type object *or*  the underlying
-JVM object is null. Returns 0 otherwise.
 
 ## tostr
 * `tostr_I(Int $val --> str)`

--- a/src/vm/jvm/QAST/Compiler.nqp
+++ b/src/vm/jvm/QAST/Compiler.nqp
@@ -2888,9 +2888,6 @@ QAST::OperationsJAST.map_classlib_core_op('continuationcontrol', $TYPE_OPS, 'con
 QAST::OperationsJAST.map_classlib_core_op('continuationinvoke', $TYPE_OPS, 'continuationinvoke', [$RT_OBJ, $RT_OBJ], $RT_OBJ, :tc, :cont);
 
 # JVM interop ops
-QAST::OperationsJAST.map_classlib_core_op('jvmeqaddr', $TYPE_OPS, 'jvmeqaddr', [$RT_OBJ, $RT_OBJ], $RT_INT, :tc);
-QAST::OperationsJAST.map_classlib_core_op('jvmisnull', $TYPE_OPS, 'jvmisnull', [$RT_OBJ], $RT_INT, :tc);
-QAST::OperationsJAST.map_classlib_core_op('jvmbootinterop', $TYPE_OPS, 'jvmbootinterop', [], $RT_OBJ, :tc);
 QAST::OperationsJAST.map_classlib_core_op('backendconfig', $TYPE_OPS, 'jvmgetconfig', [], $RT_OBJ, :tc);
 
 # Native call ops

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
@@ -7361,26 +7361,6 @@ public final class Ops {
         return in;
     }
 
-    public static long jvmeqaddr(SixModelObject a, SixModelObject b, ThreadContext tc) {
-        if (a instanceof TypeObject) {
-            return (b instanceof TypeObject) ? 1 : 0;
-        } else {
-            return (b instanceof TypeObject || ((JavaObjectWrapper)a).theObject != ((JavaObjectWrapper)b).theObject) ? 0 : 1;
-        }
-    }
-
-    public static long jvmisnull(SixModelObject a, ThreadContext tc) {
-        if (a instanceof TypeObject) {
-            return 1;
-        } else {
-            return ((JavaObjectWrapper)a).theObject == null ? 1 : 0;
-        }
-    }
-
-    public static SixModelObject jvmbootinterop(ThreadContext tc) {
-        return BootJavaInterop.RuntimeSupport.boxJava(tc.gc.bootInterop, tc.gc.bootInterop.getSTableForClass(BootJavaInterop.class));
-    }
-
     public static SixModelObject jvmgetconfig(ThreadContext tc) {
         SixModelObject hashType = tc.curFrame.codeRef.staticInfo.compUnit.hllConfig.hashType;
         SixModelObject strType = tc.curFrame.codeRef.staticInfo.compUnit.hllConfig.strBoxType;


### PR DESCRIPTION
NQP builds ok and passes `make j-test` and Rakudo builds ok and passes `make j-test`.

There are some references to `nqp::jvmbootinterop` in https://github.com/perl6/nqp/blob/master/docs/jvminterop.pod, but I'm not sure how to fix them. Also not sure what to do with https://github.com/perl6/nqp/blob/master/src/vm/jvm/runtime/org/perl6/nqp/runtime/GlobalContext.java#L203-L204 and https://github.com/perl6/nqp/blob/master/src/vm/jvm/runtime/org/perl6/nqp/runtime/BootJavaInterop.java (i.e., could some more stuff be removed?).