### PR TITLE
Make tools/build/install-moar-runner.pl possible to run on *BSD

### DIFF
--- a/tools/build/install-moar-runner.pl
+++ b/tools/build/install-moar-runner.pl
@@ -31,7 +31,7 @@ else {
         or die "Could not open $install_to: $!";
     if ($relocatable) {
         printf $fh <<'EOS';
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Sourced from https://stackoverflow.com/a/246128/1975049
 SOURCE="${BASH_SOURCE[0]}"


### PR DESCRIPTION
Related to #528, but doesn't entirely fix it since it still uses bash.