### PR TITLE
Change default profile options

### DIFF
--- a/src/HLL/CommandLine.nqp
+++ b/src/HLL/CommandLine.nqp
@@ -228,6 +228,9 @@ class HLL::CommandLine::Parser {
                         $value     := '';
                         $has-value := 1;
                     }
+                    if $opt eq 'profile-filename' {
+                        note("--profile-filename is deprecated and will be removed in a future Rakudo release. Please use --profile=<filename> instead.");
+                    }
                     nqp::die("Illegal option --$opt") unless nqp::existskey(%!options, $opt);
                     nqp::die("Option --$opt does not allow a value") if !self.wants-value($opt) && $has-value;
                     if !$has-value && self.wants-value($opt) {

--- a/src/HLL/Compiler.nqp
+++ b/src/HLL/Compiler.nqp
@@ -23,7 +23,7 @@ class HLL::Compiler does HLL::Backend::Default {
         @!stages     := nqp::split(' ', 'start parse ast ' ~ $!backend.stages());
 
         # Command options and usage.
-        @!cmdoptions := nqp::split(' ', 'e=s help|h target=s trace|t=s encoding=s output|o=s source-name=s combine version|v show-config verbose-config|V stagestats=s? ll-exception rxtrace nqpevent=s profile=s? profile-compile=s? profile-filename=s profile-stage=s repl-mode=s'
+        @!cmdoptions := nqp::split(' ', 'e=s help|h target=s trace|t=s encoding=s output|o=s source-name=s combine version|v show-config verbose-config|V stagestats=s? ll-exception rxtrace nqpevent=s profile=s? profile-compile=s? profile-kind=s profile-stage=s repl-mode=s'
 #?if js
         ~ ' substagestats beautify nqp-runtime=s perl6-runtime=s libpath=s shebang execname=s source-map'
 #?endif
@@ -164,7 +164,7 @@ class HLL::Compiler does HLL::Backend::Default {
         if nqp::existskey(%adverbs, 'profile-compile') {
             $output := $!backend.run_profiled({
                 self.compile($code, :compunit_ok(1), |%adverbs);
-            }, %adverbs<profile-compile>, %adverbs<profile-filename>);
+            }, %adverbs<profile-compile>, %adverbs<profile-kind>);
         }
         else {
             $output := self.compile($code, :compunit_ok(1), |%adverbs);
@@ -179,7 +179,7 @@ class HLL::Compiler does HLL::Backend::Default {
 
             if nqp::existskey(%adverbs, 'profile') {
                 $output := $!backend.run_profiled({ $output(|@args) },
-                    %adverbs<profile>, %adverbs<profile-filename>);
+                    %adverbs<profile>, %adverbs<profile-kind>);
             }
             elsif %adverbs<trace> {
                 $output := $!backend.run_traced(%adverbs<trace>, { $output(|@args) });
@@ -488,7 +488,7 @@ class HLL::Compiler does HLL::Backend::Default {
             }
 
             $result := %adverbs<profile-stage> eq $_
-                ?? $!backend.run_profiled(&run, '', %adverbs<profile-filename>)
+                ?? $!backend.run_profiled(&run, %adverbs<profile>, %adverbs<profile-kind>)
                 !! run();
 
             my $diff := nqp::time_n() - $timestamp;

--- a/src/HLL/Compiler.nqp
+++ b/src/HLL/Compiler.nqp
@@ -23,7 +23,7 @@ class HLL::Compiler does HLL::Backend::Default {
         @!stages     := nqp::split(' ', 'start parse ast ' ~ $!backend.stages());
 
         # Command options and usage.
-        @!cmdoptions := nqp::split(' ', 'e=s help|h target=s trace|t=s encoding=s output|o=s source-name=s combine version|v show-config verbose-config|V stagestats=s? ll-exception rxtrace nqpevent=s profile=s? profile-compile=s? profile-kind=s profile-stage=s repl-mode=s'
+        @!cmdoptions := nqp::split(' ', 'e=s help|h target=s trace|t=s encoding=s output|o=s source-name=s combine version|v show-config verbose-config|V stagestats=s? ll-exception rxtrace nqpevent=s profile=s? profile-compile=s? profile-filename=s profile-kind=s profile-stage=s repl-mode=s'
 #?if js
         ~ ' substagestats beautify nqp-runtime=s perl6-runtime=s libpath=s shebang execname=s source-map'
 #?endif
@@ -164,7 +164,7 @@ class HLL::Compiler does HLL::Backend::Default {
         if nqp::existskey(%adverbs, 'profile-compile') {
             $output := $!backend.run_profiled({
                 self.compile($code, :compunit_ok(1), |%adverbs);
-            }, %adverbs<profile-compile>, %adverbs<profile-kind>);
+            }, %adverbs<profile-filename> || %adverbs<profile-compile>, %adverbs<profile-kind>);
         }
         else {
             $output := self.compile($code, :compunit_ok(1), |%adverbs);
@@ -179,7 +179,7 @@ class HLL::Compiler does HLL::Backend::Default {
 
             if nqp::existskey(%adverbs, 'profile') {
                 $output := $!backend.run_profiled({ $output(|@args) },
-                    %adverbs<profile>, %adverbs<profile-kind>);
+                    %adverbs<profile-filename> || %adverbs<profile>, %adverbs<profile-kind>);
             }
             elsif %adverbs<trace> {
                 $output := $!backend.run_traced(%adverbs<trace>, { $output(|@args) });
@@ -488,7 +488,7 @@ class HLL::Compiler does HLL::Backend::Default {
             }
 
             $result := %adverbs<profile-stage> eq $_
-                ?? $!backend.run_profiled(&run, %adverbs<profile>, %adverbs<profile-kind>)
+                ?? $!backend.run_profiled(&run, %adverbs<profile-filename> || %adverbs<profile>, %adverbs<profile-kind>)
                 !! run();
 
             my $diff := nqp::time_n() - $timestamp;

--- a/src/vm/moar/HLL/Backend.nqp
+++ b/src/vm/moar/HLL/Backend.nqp
@@ -59,7 +59,15 @@ class HLL::Backend::MoarVM {
         }
     }
     method run_profiled($what, $filename, $kind) {
-        $kind := 'instrumented' unless $kind;
+        unless $kind {
+            if $filename ~~ / '.html' | '.json' | '.sql' $ / {
+                $kind := 'instrumented';
+	    } elsif $filename ~~ / '.mvmheap' $ / {
+                $kind := 'heap';
+	    } else {
+                $kind := 'instrumented';
+            }
+        }
 
         self.ensure_prof_routines();
 

--- a/src/vm/moar/HLL/Backend.nqp
+++ b/src/vm/moar/HLL/Backend.nqp
@@ -73,7 +73,7 @@ class HLL::Backend::MoarVM {
 
         if $kind eq "heap" {
             unless $filename {
-                $filename := 'heap-snapshot-' ~ nqp::time_n();
+                $filename := 'heap-snapshot-' ~ nqp::time_n() ~ '.mvmheap';
             }
             $prof_start_sub(nqp::hash('kind', $kind, 'path', $filename));
         } else {


### PR DESCRIPTION
Now `--profile(-compile)=<foo>` will set the filename and
`--profile-kind=<foo>` will set whether it's an instrumented or heap
profile.

If this is merged I'll create a corresponding rakudo PR to correct its help output.