### PR TITLE
Added detection of moar executable in --prefix

### DIFF
--- a/tools/lib/NQP/Config/NQP.pm
+++ b/tools/lib/NQP/Config/NQP.pm
@@ -27,7 +27,7 @@ sub configure_backends {
     else {
         my $have_gen_moar = defined $options->{'gen-moar'};
         my $moar_exe = can_run( $self->moar_config->{moar} ) || can_run('moar');
-        if ( $moar_exe ) {
+        if ( $moar_exe || $have_gen_moar ) {
             say "===WARNING!===\n",
               "  No backends specified on the command line.\n",
               "  Using 'moar' because we found '$moar_exe' executable."

--- a/tools/lib/NQP/Config/NQP.pm
+++ b/tools/lib/NQP/Config/NQP.pm
@@ -1,3 +1,4 @@
+## Please see file perltidy.ERR
 package NQP::Config::NQP;
 use v5.10.1;
 use strict;
@@ -25,10 +26,11 @@ sub configure_backends {
     }
     else {
         my $have_gen_moar = defined $options->{'gen-moar'};
-        if ( $have_gen_moar || can_run('moar') ) {
+        my $moar_exe = can_run( $self->moar_config->{moar} ) || can_run('moar');
+        if ( $moar_exe ) {
             say "===WARNING!===\n",
               "  No backends specified on the command line.\n",
-              "  Using 'moar' because we found it in the PATH."
+              "  Using 'moar' because we found '$moar_exe' executable."
               unless $have_gen_moar;
             $self->use_backend('moar');
         }
@@ -162,6 +164,20 @@ sub post_active_backends {
     $self->sorry(@errors) if @errors;
 }
 
+sub moar_config {
+    my $self        = shift;
+    my $moar_config = $self->backend_config('moar');
+    return $moar_config if $moar_config->{moar};
+    my $sdkroot = $self->cfg('sdkroot');
+    my $prefix  = $self->cfg('prefix');
+    my $moar_prefix =
+      $sdkroot ? File::Spec->catdir( $sdkroot, $prefix ) : $prefix;
+    my $moar_exe = $self->opt('with-moar')
+      || File::Spec->catfile( $moar_prefix, 'bin', "moar" . $self->cfg('exe') );
+    return $self->backend_config( 'moar',
+        { moar => $moar_exe, moar_prefix => $moar_prefix, } );
+}
+
 sub gen_moar {
     my $self = shift;
 
@@ -176,18 +192,13 @@ sub gen_moar {
     my @errors;
 
     my $prefix   = $config->{prefix};
-    my $exe      = $config->{exe};
-    my $sdkroot  = $config->{sdkroot};
     my $gen_moar = $options->{'gen-moar'};
     my @opts     = @{ $options->{'moar-option'} || [] };
     push @opts, "--optimize";
     my $startdir     = $config->{base_dir};
     my $git_protocol = $options->{'git-protocol'} || 'https';
     my $try_generate;
-    my $moar_prefix =
-      $sdkroot ? File::Spec->catdir( $sdkroot, $prefix ) : $prefix;
-    my $moar_exe = $options->{'with-moar'}
-      || File::Spec->catfile( $moar_prefix, 'bin', "moar$exe" );
+    my $moar_exe            = $self->moar_config->{moar};
     my $moar_version_output = "";
 
     if ( $self->is_executable($moar_exe) ) {
@@ -243,8 +254,7 @@ sub gen_moar {
         chdir( $self->base_path('MoarVM') ) or die $!;
 
         print "\nConfiguring and building MoarVM ...\n";
-        my @cmd =
-          ( $^X, "Configure.pl", @opts, qq{--prefix=$prefix},
+        my @cmd = ( $^X, "Configure.pl", @opts, qq{--prefix=$prefix},
             '--make-install' );
         print "@cmd\n";
         system_or_die(@cmd);
@@ -252,8 +262,6 @@ sub gen_moar {
         chdir($cwd);
     }
 
-    $self->backend_config( 'moar',
-        { moar => $moar_exe, moar_prefix => $moar_prefix, } );
     $self->{impls}{moar}{ok} = 1;
 
 # XXX What'd be the point of overriding the autodetected make with
@@ -292,7 +300,10 @@ sub probe_node {
     # the javascript thingy is called 'nodejs' there
     for my $binary (qw/node nodejs /) {
         my $version_str;
-        my $ok = run( command => [ $binary, '-v' ], buffer => \$version_str );
+        my $ok = run(
+            command => [ $binary, '-v' ],
+            buffer  => \$version_str
+        );
         if ( $ok && $version_str =~ /^v\d/ ) {
             return $binary;
         }


### PR DESCRIPTION
moar backend will be implicitly chosen if moar executable found either
in --prefix or in PATH.