### PR TITLE
Parse |, ||, &, && prefixes not in nibble

### DIFF
--- a/src/QRegex/P6Regex/Grammar.nqp
+++ b/src/QRegex/P6Regex/Grammar.nqp
@@ -132,15 +132,6 @@ grammar QRegex::P6Regex::Grammar is HLL::Grammar {
             for $OLDRX { %*RX{$_.key} := $_.value; }
         }
         <.ws>
-        [
-          <!rxstopper>
-          [
-          |  '||' { $*SEQ := 1; }
-          |  '|'
-          |  '&&'
-          |  '&'
-          ] <.ws>
-        ]?
         <termseq>
         [
         || <?infixstopper>
@@ -168,21 +159,25 @@ grammar QRegex::P6Regex::Grammar is HLL::Grammar {
     }
 
     token termaltseq {
+        [ <!rxstopper> '||' { $*SEQ := 1; } <.ws> ]?
         <termconjseq>
         [ <!infixstopper> '||' <.ws> { $*SEQ := 1; } <termconjseq> ]*
     }
 
     token termconjseq {
+        [ <!rxstopper> '&&' { $*SEQ := 0; } <.ws> ]?
         <termalt>
         [ <!infixstopper> '&&' <.ws> { $*SEQ := 0; } <termalt> ]*
     }
 
     token termalt {
+        [ <!rxstopper> '|' <.ws> ]?
         <termconj>
         [ <!infixstopper> '|' <![|]> <.ws> { $*SEQ := 0; } <termconj> ]*
     }
 
     token termconj {
+        [ <!rxstopper> '&' <.ws> ]?
         <termish>
         [ <!infixstopper> '&' <![&]> <.ws> { $*SEQ := 0; } <termish> ]*
     }

--- a/t/qregex/rx_metachars
+++ b/t/qregex/rx_metachars
@@ -102,7 +102,7 @@ b&			bcd		[Null regex]	conjunction (&) - null right arg illegal
 &			&		[Null regex]	conjunction (&) - literal must be escaped
 a&|b			a&|b		[Null regex]	alternation and conjunction (&|) - parse error
 &			&		[Null regex]	conjunction (&) - literal must be escaped
-a|&b			a|&b		[Null regex]	alternation and conjunction (|&) - parse error
+a|&b			a|&b		y	alternation and conjunction (|&) - leading & inside | is okay
 |d|b			abc		y	leading alternation ignored
  |d|b			abc		y	leading alternation ignored
 |d |b			abc		y	leading alternation ignored


### PR DESCRIPTION
Needed for https://github.com/rakudo/rakudo/pull/2907 to work.