### PR TITLE
A solution for nqp-configure submodule updates.

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -37,9 +37,7 @@ qx{git submodule sync --quiet 3rdparty/nqp-configure && git submodule --quiet up
     }
 }
 
-use lib (
-    "../3rdparty/nqp-configure/lib",
-    "$FindBin::Bin/tools/lib",
+use lib ( "$FindBin::Bin/tools/lib",
     "$FindBin::Bin/3rdparty/nqp-configure/lib", );
 use NQP::Config qw<system_or_die>;
 use NQP::Config::NQP;

--- a/Configure.pl
+++ b/Configure.pl
@@ -12,25 +12,34 @@ use File::Path;
 use FindBin;
 
 BEGIN {
-    my $force_update = !!grep { $_ eq '--submodule-update' } @ARGV;
-    if ( $force_update || !-e '3rdparty/nqp-configure/LICENSE' ) {
+    my $set_config = !qx{git config nqp.initialized};
+    if ( !-e '3rdparty/nqp-configure/LICENSE' ) {
         print "Updating nqp-configure submodule...\n";
         my $msg =
 qx{git submodule sync --quiet 3rdparty/nqp-configure && git submodule --quiet update --init 3rdparty/nqp-configure 2>&1};
-        if ( $? >> 8 == 0 ) { print "OK\n" }
+        if ( $? >> 8 == 0 ) {
+            say "OK";
+            $set_config = 1;
+        }
         else {
             if ( $msg =~ /[']([^']+)[']\s+already exists and is not an empty/ )
             {
-                print
-"\n===SORRY=== ERROR: Cannot update submodule because directory exists and is not empty.\n"
+                print "\n===SORRY=== ERROR: "
+                  . "Cannot update submodule because directory exists and is not empty.\n"
                   . ">>> Please delete the following folder and try again:\n$1\n\n";
                 exit 1;
             }
         }
     }
+    if ($set_config) {
+        system("git config submodule.recurse true");
+        system("git config nqp.initialized 1");
+    }
 }
 
-use lib ( "$FindBin::Bin/tools/lib",
+use lib (
+    "../3rdparty/nqp-configure/lib",
+    "$FindBin::Bin/tools/lib",
     "$FindBin::Bin/3rdparty/nqp-configure/lib", );
 use NQP::Config qw<system_or_die>;
 use NQP::Config::NQP;
@@ -59,7 +68,7 @@ MAIN: {
         'github-user=s',    'nqp-repo=s',
         'moar-repo=s',      'expand=s',
         'out=s',            'set-var=s@',
-        'no-relocatable',   'submodule-update',
+        'no-relocatable',
       )
       or do {
         print_help();
@@ -98,7 +107,7 @@ MAIN: {
 
     $cfg->expand_template;
 
-    unless ( $cfg->opt('expand') || defined $cfg->opt('submodule-update') ) {
+    unless ( $cfg->opt('expand') ) {
         my $make = $cfg->cfg('make');
         unless ( $cfg->opt('no-clean') ) {
             no warnings;

--- a/tools/lib/NQP/Config/NQP.pm
+++ b/tools/lib/NQP/Config/NQP.pm
@@ -51,13 +51,16 @@ sub configure_refine_vars {
     my $self = shift;
 
     unless ( $self->cfg('prefix') ) {
-        my $moar_prefix = $self->moar_config->{moar_prefix};
+        my $moar_conf   = $self->moar_config;
+        my $moar_prefix = $moar_conf->{moar_prefix};
+        my $moar        = $moar_conf->{moar};
         if ($moar_prefix) {
             $self->set( prefix => $moar_prefix );
             $self->note(
                 'ATTENTION',
-                "No --prefix supplied, using moar executable location.\n",
-                "Building and installing to '$moar_prefix'"
+                "No --prefix supplied, ",
+                "building and installing to '$moar_prefix'\n",
+                "Based on found executable $moar"
             );
         }
     }
@@ -205,7 +208,8 @@ sub moar_config {
             $moar_exe ||= File::Spec->catfile( $moar_prefix, 'bin',
                 "moar" . $self->cfg('exe') );
         }
-        elsif (!defined $self->opt('sysroot')) {
+        elsif ( !defined $self->opt('sysroot') ) {
+
             # Pick from PATH
             $moar_exe = can_run('moar');
             if ($moar_exe) {


### PR DESCRIPTION
With this PR `Configure.pl` would set git configuration variable `submodule.recurse` to true once. With this variable `git` would also auto-update all submodules if necessary upon each `pull` operation. `Configure.pl` would also set `nqp.initialized` variable to prevent repetitive changing of `submodule.recurse` on each run as this might be annoying if someone decides to reset it.