### PR TITLE
Use --release 9 instead of -source 1.9 in the JVM's Makefile

### DIFF
--- a/tools/templates/jvm/Makefile.in
+++ b/tools/templates/jvm/Makefile.in
@@ -130,7 +130,7 @@ j-install: j-all
 
 $(RUNTIME_JAR): $(RUNTIME_JAVAS) @mkquot(@script(gen-jvm-properties.pl)@)@
 	$(PERL5) -MExtUtils::Command -e mkpath bin
-	$(JAVAC) -source 1.9 -cp @q($(THIRDPARTY_JARS))@ -g -d bin -encoding UTF8 $(RUNTIME_JAVAS)
+	$(JAVAC) --release 9 -cp @q($(THIRDPARTY_JARS))@ -g -d bin -encoding UTF8 $(RUNTIME_JAVAS)
 	$(PERL5) @shquot(@script(gen-jvm-properties.pl)@)@ . @q($(THIRDPARTY_JARS))@ > jvmconfig.properties
 	$(PERL5) @shquot(@script(gen-jvm-properties.pl)@)@ @nfpq(@prefix@)@ @q($(THIRDPARTY_JARS))@ > @nfpq(bin/jvmconfig.properties)@
 	$(JAR) cf0 nqp-runtime.jar -C @nfp(bin/)@ .


### PR DESCRIPTION
This shuts up warnings about the target being the wrong version of the
JDK and warnings about -bootclasspath being needed.