### PR TITLE
[js] Refactor src/vm/js/nqp-runtime/global-context.js

### DIFF
--- a/src/vm/js/nqp-runtime/bootstrap.js
+++ b/src/vm/js/nqp-runtime/bootstrap.js
@@ -21,8 +21,7 @@ const globalContext = require('./global-context.js');
 
 const core = new SerializationContext('__6MODEL_CORE__');
 core.description = 'core SC';
-
-globalContext.initialize(context => context.scs['__6MODEL_CORE__'] = core);
+globalContext.initialize(context => context.scs.set('__6MODEL_CORE__', core));
 
 function addToScWithSt(obj) {
   core.rootObjects.push(obj);

--- a/src/vm/js/nqp-runtime/core.js
+++ b/src/vm/js/nqp-runtime/core.js
@@ -597,9 +597,6 @@ op.scwbdisable = function() {
   return ++globalContext.context.scwbDisableDepth;
 };
 
-
-globalContext.initialize(context => context.compilerRegistry = new Map());
-
 op.bindcomp = function(language, compiler) {
   globalContext.context.compilerRegistry.set(language, compiler);
   return compiler;
@@ -857,7 +854,6 @@ class BuildSourceMap extends NQPObject {
 
 exports.createSourceMap = createSourceMap;
 exports.buildSourceMap = new BuildSourceMap();
-
 
 class JavaScriptCompiler extends NQPObject {
   $$mangleCode(code) {

--- a/src/vm/js/nqp-runtime/deserialization.js
+++ b/src/vm/js/nqp-runtime/deserialization.js
@@ -45,7 +45,7 @@ const REFVAR_CLONED_CODEREF = 12;
 /** All the loaded serialization contexts using their unique IDs as keys */
 
 module.exports.wval = function(handle, idx) {
-  return globalContext.context.scs[handle].rootObjects[idx];
+  return globalContext.context.scs.get(handle).rootObjects[idx];
 };
 
 op.deserialize = function(currentHLL, blob, sc, sh, codeRefs, conflicts, cuids, setupWVals) {
@@ -65,7 +65,9 @@ op.deserialize = function(currentHLL, blob, sc, sh, codeRefs, conflicts, cuids, 
 };
 
 op.createsc = function(handle) {
-  return (globalContext.context.scs[handle] = new SerializationContext(handle));
+  const sc = new SerializationContext(handle);
+  globalContext.context.scs.set(handle, sc);
+  return sc;
 };
 
 op.scsetdesc = function(sc, desc) {
@@ -552,7 +554,7 @@ class BinaryCursor {
     this.sc.deps = deps;
 
     for (const i in dependencies) {
-      const dep = globalContext.context.scs[dependencies[i][0]];
+      const dep = globalContext.context.scs.get(dependencies[i][0]);
       if (!dep) {
         console.log(
             'Missing dependencie, can\'t find serialization context handle:',
@@ -630,7 +632,7 @@ class BinaryCursor {
         if (codeRef.staticVars) {
           for (const name in codeRef.staticVars) {
             if (codeRef.staticVars[name] instanceof Array) {
-              codeRef.staticVars[name] = globalContext.context.scs[codeRef.staticVars[name][0]].rootObjects[codeRef.staticVars[name][1]];
+              codeRef.staticVars[name] = globalContext.context.scs.get(codeRef.staticVars[name][0]).rootObjects[codeRef.staticVars[name][1]];
             } else if (typeof codeRef.staticVars[name] === 'number') {
               codeRef.staticVars[name] = sc.rootObjects[codeRef.staticVars[name]];
             }
@@ -640,7 +642,7 @@ class BinaryCursor {
         if (codeRef.contVars) {
           for (const name in codeRef.contVars) {
             if (codeRef.contVars[name] instanceof Array) {
-              codeRef.contVars[name] = globalContext.context.scs[codeRef.contVars[name][0]].rootObjects[codeRef.contVars[name][1]];
+              codeRef.contVars[name] = globalContext.context.scs.get(codeRef.contVars[name][0]).rootObjects[codeRef.contVars[name][1]];
             } else if (typeof codeRef.contVars[name] === 'number') {
               codeRef.contVars[name] = sc.rootObjects[codeRef.contVars[name]];
             }

--- a/src/vm/js/nqp-runtime/hll.js
+++ b/src/vm/js/nqp-runtime/hll.js
@@ -13,8 +13,6 @@ exports.op = op;
 
 const globalContext = require('./global-context.js');
 
-globalContext.initialize(context => context.hllSyms = new Map());
-
 op.gethllsym = function(hllName, name) {
   const hllSyms = globalContext.context.hllSyms;
   if (hllSyms.has(hllName) && hllSyms.get(hllName).has(name)) {
@@ -88,22 +86,25 @@ op.hllizefor = function(ctx, obj, language) {
   }
 };
 
-globalContext.initialize(context => context.hllConfigs = {});
-
 function getHLL(language) {
   const hllConfigs = globalContext.context.hllConfigs;
 
-  if (!hllConfigs[language]) {
-    hllConfigs[language] = new Map;
-    hllConfigs[language].set('slurpy_array', BOOT.Array);
-    hllConfigs[language].set('list', BOOT.Array);
-    hllConfigs[language].set('true_value', Null);
-    hllConfigs[language].set('false_value', Null);
-
-    // For serialization purposes
-    hllConfigs[language].set('name', language);
+  if (hllConfigs.has(language)) {
+    return hllConfigs.get(language);
   }
-  return hllConfigs[language];
+
+  const hllConfig = new Map([
+    ['slurpy_array', BOOT.Array],
+    ['list',         BOOT.Array],
+    ['true_value',   Null      ],
+    ['false_value',  Null      ],
+    // For serialization purposes.
+    ['name',         language  ],
+  ]);
+
+  hllConfigs.set(language, hllConfig);
+
+  return hllConfig;
 }
 
 exports.getHLL = getHLL;

--- a/src/vm/js/nqp-runtime/runtime.js
+++ b/src/vm/js/nqp-runtime/runtime.js
@@ -144,14 +144,13 @@ exports.loaderCtx = null;
 
 /* dependencies */
 
-globalContext.initialize(context => context.loadedCache = new Map());
-
 function loadWithCache(code) {
   const loadedCache = globalContext.context.loadedCache;
 
   if (!loadedCache.has(code)) {
     loadedCache.set(code, code(module.exports, false));
   }
+
   return loadedCache.get(code);
 }
 
@@ -842,16 +841,15 @@ for (const prop in props) {
 exports.buildSourceMap = core.buildSourceMap;
 exports.createSourceMap = core.createSourceMap;
 
-exports.ZERO = JSBI.BigInt(0);
-exports.asIntN = asIntN.asIntN;
+exports.ZERO    = JSBI.BigInt(0);
+exports.asIntN  = asIntN.asIntN;
 exports.asUintN = asIntN.asUintN;
-exports.BigInt = JSBI.BigInt;
+exports.BigInt  = JSBI.BigInt;
 
-module.exports.freshGlobalContext = globalContext.freshGlobalContext;
-module.exports.setGlobalContext = globalContext.setGlobalContext;
-
-module.exports.saveThisGlobalContext = globalContext.saveThisGlobalContext;
-module.exports.restoreThisGlobalContext = globalContext.restoreThisGlobalContext;
+module.exports.freshGlobalContext       = (setup)    => globalContext.freshGlobalContext(setup);
+module.exports.setGlobalContext         = (context)  => globalContext.setGlobalContext(context);
+module.exports.saveThisGlobalContext    = (callback) => globalContext.saveThisGlobalContext(callback);
+module.exports.restoreThisGlobalContext = (callback) => globalContext.restoreThisGlobalContext(callback);
 
 exports.loadCompileTimeDependency = /*async*/ function(unit) {
   const fakeModule = {};

--- a/src/vm/js/nqp-runtime/serialization-context.js
+++ b/src/vm/js/nqp-runtime/serialization-context.js
@@ -2,8 +2,6 @@
 
 const globalContext = require('./global-context.js');
 
-globalContext.initialize(context => context.scs = {});
-
 const NQPObject = require('./nqp-object.js');
 
 /**

--- a/src/vm/js/nqp-runtime/serialization.js
+++ b/src/vm/js/nqp-runtime/serialization.js
@@ -1040,7 +1040,7 @@ op.scsetcode = function(sc, idx, obj) {
 };
 
 op.neverrepossess = function(obj) {
-  globalContext.context.neverRepossess.set(obj, true);
+  globalContext.context.neverRepossess.add(obj);
   return obj;
 };
 

--- a/src/vm/js/nqp-runtime/sixmodel.js
+++ b/src/vm/js/nqp-runtime/sixmodel.js
@@ -10,12 +10,6 @@ const Null = require('./null.js');
 
 const globalContext = require('./global-context.js');
 
-globalContext.initialize(context => {
-  context.compilingSCs = [];
-  context.scwbDisableDepth = 0;
-  context.neverRepossess = new Map();
-});
-
 const constants = require('./constants.js');
 
 /* Needed for setting defaults values of attrs for objects */
@@ -46,7 +40,7 @@ const NativeStrArg = nativeArgs.NativeStrArg;
 function scwb() {
   const compilingSCs = globalContext.context.compilingSCs;
 
-  if (compilingSCs.length == 0 || globalContext.context.scwbDisableDepth || globalContext.context.neverRepossess.get(this)) {
+  if (compilingSCs.length == 0 || globalContext.context.scwbDisableDepth || globalContext.context.neverRepossess.has(this)) {
     return;
   }
 


### PR DESCRIPTION
This cleans up its code by encapsulating most of it in a `GlobalContextWrapper` singleton and moving all property declarations on `GlobalContext` to within its constructor rather than from other modules to avoid deoptimizations.

I'm making this a draft pullreq since this is my first time dealing with the JS VM and I want to refactor this a bit more so `GlobalContext` mutates its own properties, not the other modules.

Passes `make test`.