### PR TITLE
Change associativity of exponentiation to 'right'

### DIFF
--- a/src/NQP/Grammar.nqp
+++ b/src/NQP/Grammar.nqp
@@ -744,7 +744,7 @@ grammar NQP::Grammar is HLL::Grammar {
 
     my %methodop       := nqp::hash('prec', 'y=', 'assoc', 'unary');
     my %autoincrement  := nqp::hash('prec', 'x=', 'assoc', 'unary');
-    my %exponentiation := nqp::hash('prec', 'w=', 'assoc', 'left');
+    my %exponentiation := nqp::hash('prec', 'w=', 'assoc', 'right');
     my %symbolic_unary := nqp::hash('prec', 'v=', 'assoc', 'unary');
     my %multiplicative := nqp::hash('prec', 'u=', 'assoc', 'left');
     my %additive       := nqp::hash('prec', 't=', 'assoc', 'left');

--- a/t/nqp/013-op.t
+++ b/t/nqp/013-op.t
@@ -1,6 +1,6 @@
 # checking basic operands and circumfix:( )
 
-plan(33);
+plan(39);
 
 ##Additive operators
 ok(      1+2  == 3, 'Checking addition 1+2');
@@ -16,6 +16,14 @@ ok(   4*(3+5) == 32, 'Checking parenthesized statements 4*(3+5)');
 ok(   12/4*3  ==  9, 'Checking compound statements 12/4*3');
 ok( 12/(4*3)  ==  1, 'Checking compound statements 12/(4*3)');
 ok(   5-3*2   == -1, 'Checking compound statements 5-3*2');
+
+##Exponentiation operator
+ok(     2**6  == 64, 'Checking exponentiation 2**6');
+ok(  2**2**3  == 256, 'Checking associativity 2**2**3');
+ok(   1+2**3  == 9,  'Checking precedence against additive');
+ok(   3*2**3  == 24, 'Checking precedence against multiplicative');
+ok(    -2**2  == +4, 'Checking precedence against tight unary minus');
+ok(   - 2**2  == -4, 'Checking precedence against loose unary minus');
 
 ##Modulo operator
 ok(      8%3  == 2, 'Checking modulo 8%3');


### PR DESCRIPTION
Just stumbled on this:

https://github.com/perl6/nqp/blob/7cccdb13e28b2aea7321bdef02408f842183d477/src/NQP/Grammar.nqp#L747

Exponentiation should be right-associative (like it is in Perl 6), no? The test suite passed before and passes after this PR, so I am not sure if this will have fall-out downstream. The second commit adds tests for the `**` operator which hasn't been exercised at all.

Maybe this is an instance of "if it's not (too) broken, don't fix it"?