### PR TITLE
[IP6NS Grant] Make socket family handling portable

### DIFF
--- a/src/vm/js/const_map.nqp
+++ b/src/vm/js/const_map.nqp
@@ -91,5 +91,10 @@ my %const_map := nqp::hash(
     'UNAME_SYSNAME',              0,
     'UNAME_RELEASE',              1,
     'UNAME_VERSION',              2,
-    'UNAME_MACHINE',              3
+    'UNAME_MACHINE',              3,
+
+    'SOCKET_FAMILY_UNSPEC', 0,
+    'SOCKET_FAMILY_INET',   1,
+    'SOCKET_FAMILY_INET6',  2,
+    'SOCKET_FAMILY_UNIX',   3
 );

--- a/src/vm/jvm/QAST/Compiler.nqp
+++ b/src/vm/jvm/QAST/Compiler.nqp
@@ -2135,6 +2135,11 @@ my %const_map := nqp::hash(
     'BINARY_SIZE_16_BIT',         4,
     'BINARY_SIZE_32_BIT',         8,
     'BINARY_SIZE_64_BIT',        12,
+
+    'SOCKET_FAMILY_UNSPEC',       0,
+    'SOCKET_FAMILY_INET',         1,
+    'SOCKET_FAMILY_INET6',        2,
+    'SOCKET_FAMILY_UNIX',         3,
 );
 QAST::OperationsJAST.add_core_op('const', -> $qastcomp, $op {
     if nqp::existskey(%const_map, $op.name) {

--- a/src/vm/jvm/QAST/Compiler.nqp
+++ b/src/vm/jvm/QAST/Compiler.nqp
@@ -2218,8 +2218,8 @@ QAST::OperationsJAST.map_classlib_core_op('linesasync', $TYPE_OPS, 'linesasync',
 QAST::OperationsJAST.map_classlib_core_op('spurtasync', $TYPE_OPS, 'spurtasync', [$RT_OBJ, $RT_OBJ, $RT_OBJ, $RT_OBJ, $RT_OBJ], $RT_OBJ, :tc);
 
 QAST::OperationsJAST.map_classlib_core_op('socket', $TYPE_OPS, 'socket', [$RT_INT], $RT_OBJ, :tc);
-QAST::OperationsJAST.map_classlib_core_op('connect', $TYPE_OPS, 'connect', [$RT_OBJ, $RT_STR, $RT_INT], $RT_OBJ, :tc);
-QAST::OperationsJAST.map_classlib_core_op('bindsock', $TYPE_OPS, 'bindsock', [$RT_OBJ, $RT_STR, $RT_INT, $RT_INT], $RT_OBJ, :tc);
+QAST::OperationsJAST.map_classlib_core_op('connect', $TYPE_OPS, 'connect', [$RT_OBJ, $RT_STR, $RT_INT, $RT_INT], $RT_OBJ, :tc);
+QAST::OperationsJAST.map_classlib_core_op('bindsock', $TYPE_OPS, 'bindsock', [$RT_OBJ, $RT_STR, $RT_INT, $RT_INT, $RT_INT], $RT_OBJ, :tc);
 QAST::OperationsJAST.map_classlib_core_op('accept', $TYPE_OPS, 'accept', [$RT_OBJ], $RT_OBJ, :tc);
 QAST::OperationsJAST.map_classlib_core_op('getport', $TYPE_OPS, 'getport', [$RT_OBJ], $RT_INT, :tc);
 

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
@@ -436,25 +436,62 @@ public final class Ops {
         return h;
     }
 
-    public static SixModelObject connect(SixModelObject obj, String host, long port, ThreadContext tc) {
+	public static final int SOCKET_FAMILY_UNSPEC = 0;
+	public static final int SOCKET_FAMILY_INET   = 1;
+	public static final int SOCKET_FAMILY_INET6  = 2;
+	public static final int SOCKET_FAMILY_UNIX   = 3;
+
+    public static SixModelObject connect(SixModelObject obj, String host, long port, long family, ThreadContext tc) {
         IOHandleInstance h = (IOHandleInstance)obj;
-        if (h.handle instanceof SocketHandle) {
-            ((SocketHandle)h.handle).connect(tc, host, (int) port);
-        } else {
-            ExceptionHandling.dieInternal(tc,
-                "This handle does not support connect");
-        }
+
+		switch ((int) family) {
+			case SOCKET_FAMILY_UNSPEC:
+			case SOCKET_FAMILY_INET:
+			case SOCKET_FAMILY_INET6:
+				if (h.handle instanceof SocketHandle) {
+					((SocketHandle)h.handle).connect(tc, host, (int) port);
+				} else {
+					ExceptionHandling.dieInternal(tc,
+						"This handle does not support connect");
+				}
+				break;
+			case SOCKET_FAMILY_UNIX:
+				ExceptionHandling.dieInternal(tc,
+					"UNIX sockets are not supported on the JVM");
+				break;
+			default:
+				ExceptionHandling.dieInternal(tc,
+					"Unsupported socket family: " + Long.toString(family));
+				break;
+		}
+
         return obj;
     }
 
-    public static SixModelObject bindsock(SixModelObject obj, String host, long port, long backlog, ThreadContext tc) {
+    public static SixModelObject bindsock(SixModelObject obj, String host, long port, long family, long backlog, ThreadContext tc) {
         IOHandleInstance h = (IOHandleInstance)obj;
-        if (h.handle instanceof IIOBindable) {
-            ((IIOBindable)h.handle).bind(tc, host, (int) port, (int)backlog);
-        } else {
-            ExceptionHandling.dieInternal(tc,
-                "This handle does not support bind");
-        }
+
+		switch ((int) family) {
+			case SOCKET_FAMILY_UNSPEC:
+			case SOCKET_FAMILY_INET:
+			case SOCKET_FAMILY_INET6:
+				if (h.handle instanceof IIOBindable) {
+					((IIOBindable)h.handle).bind(tc, host, (int) port, (int) backlog);
+				} else {
+					ExceptionHandling.dieInternal(tc,
+						"This handle does not support bind");
+				}
+				break;
+			case SOCKET_FAMILY_UNIX:
+				ExceptionHandling.dieInternal(tc,
+					"UNIX sockets are not supported on the JVM");
+				break;
+			default:
+				ExceptionHandling.dieInternal(tc,
+					"Unsupported socket family: " + Long.toString(family));
+				break;
+		}
+
         return obj;
     }
 

--- a/src/vm/moar/QAST/QASTOperationsMAST.nqp
+++ b/src/vm/moar/QAST/QASTOperationsMAST.nqp
@@ -2251,6 +2251,11 @@ my %const_map := nqp::hash(
     'BINARY_SIZE_16_BIT',         4,
     'BINARY_SIZE_32_BIT',         8,
     'BINARY_SIZE_64_BIT',        12,
+
+    'SOCKET_FAMILY_UNSPEC',       0,
+    'SOCKET_FAMILY_INET',         1,
+    'SOCKET_FAMILY_INET6',        2,
+    'SOCKET_FAMILY_UNIX',         3,
 );
 QAST::MASTOperations.add_core_op('const', -> $qastcomp, $op {
     if nqp::existskey(%const_map, $op.name) {


### PR DESCRIPTION
MoarVM requires that the socket family be a separate parameter for
nqp::bind_sk and nqp::connect_sk from the port; update the JVM
accordingly and use the same platform-independent constants here as
in MoarVM.

Related to https://github.com/rakudo/rakudo/issues/3007

This still needs testing.