### PR TITLE
Fix for a rare case of empty mast_frames hash

### DIFF
--- a/src/vm/moar/QAST/QASTOperationsMAST.nqp
+++ b/src/vm/moar/QAST/QASTOperationsMAST.nqp
@@ -603,8 +603,10 @@ QAST::MASTOperations.add_core_op('list_b', -> $qastcomp, $op {
                 unless nqp::istype($_, QAST::Block);
             my $cuid  := $_.cuid();
             my $frame := $qastcomp.mast_frames{$cuid};
-            %core_op_generators{'getcode'}($item_reg, $frame);
-            %core_op_generators{'push_o'}($arr_reg, $item_reg);
+            if $frame {
+                %core_op_generators{'getcode'}($item_reg, $frame);
+                %core_op_generators{'push_o'}($arr_reg, $item_reg);
+            }
         }
         $regalloc.release_register($item_reg, $MVM_reg_obj);
         my $ensure_return_register := MAST::InstructionList.new($arr_reg, $MVM_reg_obj);


### PR DESCRIPTION
Caused by a bug reported in rakudo/rakudo#3096. This fix is somewhat of
a guess because I'm not familiar with QAST->MAST compilation. But the
logic I put behind it: if no frames found in mast_frames then just do
nothing.