### PR TITLE
Provide better compatibility with Perl6 Metamodel

### DIFF
--- a/src/how/NQPConcreteRoleHOW.nqp
+++ b/src/how/NQPConcreteRoleHOW.nqp
@@ -165,7 +165,7 @@ knowhow NQPConcreteRoleHOW {
         @attrs
     }
 
-    method roles($obj) {
+    method roles($obj, :$transitive = 0) {
         @!roles
     }
 

--- a/src/how/NQPParametricRoleHOW.nqp
+++ b/src/how/NQPParametricRoleHOW.nqp
@@ -195,7 +195,7 @@ knowhow NQPParametricRoleHOW {
         @attrs
     }
 
-    method roles($obj, :$transitive) {
+    method roles($obj, :$transitive = 0) {
         @!roles
     }
 }


### PR DESCRIPTION
Add `:transitive` parameter for method `roles`. Make the parameter optional on `NQPParametricRoleHOW`.