### PR TITLE
Prevent silently swallowing errors on submodule update

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -31,6 +31,12 @@ qx{git submodule sync --quiet 3rdparty/nqp-configure && git submodule --quiet up
                       . ">>> Please delete the following folder and try again:\n$1\n\n";
                     exit 1;
                 }
+                else {
+                    print "\n===SORRY=== ERROR: "
+                      . "Updating the submodule failed for an unknown reason. The error message was:\n"
+                      . $msg;
+                    exit 1;
+                }
             }
         }
         if ($set_config) {


### PR DESCRIPTION
Same as [rakudo/rakudo#3340](https://github.com/rakudo/rakudo/pull/3340).

Configure.pl seems to silently ignore nqp-configure submodule update failures. This PR makes this more vocal.