### PR TITLE
An attempt to fix nqp-runtime.jar dependency

### DIFF
--- a/tools/templates/jvm/Makefile.in
+++ b/tools/templates/jvm/Makefile.in
@@ -25,7 +25,7 @@ RUNTIME_JAVAS = \
 
 @bsv(RUNTIME)@ = nqp-runtime.@bext@
 THIRDPARTY_JARS = $(ASM)@cpsep@$(ASMTREE)@cpsep@$(JLINE)@cpsep@$(JNA)
-@bpv(RUNNER_JARS)@ = @nfplq(nqp-runtime.@bext@ $(ASM) $(ASMTREE) $(JLINE) $(JNA))@
+@bpv(RUNNER_JARS)@ = @nfplq($(ASM) $(ASMTREE) $(JLINE) $(JNA))@
 @bpv(RUNNER_LIBS)@ = @nfplq(nqp.@bext@)@
 @bpv(EVAL_CLIENT)@ = @nfp(tools/jvm/eval-client.pl)@
 

--- a/tools/templates/jvm/nqp-j.in
+++ b/tools/templates/jvm/nqp-j.in
@@ -2,4 +2,4 @@
 
 @insert(runner-prelude)@
 
-@exec(java)@ -Xss1m -Xmx1324m -Xbootclasspath/a:"@cur_dir@@envvar(LIB_DIR)@@cpsep@@nfp(@envvar(JAR_DIR)@/nqp-runtime.jar)@@cpsep@@nfp(@envvar(JAR_DIR)@/@asmfile@)@@cpsep@@nfp(@envvar(JAR_DIR)@/@jlinefile@)@@cpsep@@nfp(@envvar(JAR_DIR)@/@jnafile@)@@cpsep@@nfp(@envvar(LIB_DIR)@/nqp.jar)@" -cp "@cur_dir@@envvar(LIB_DIR)@" nqp "@sh_allparams@"
+@exec(java)@ -Xss1m -Xmx1324m -Xbootclasspath/a:"@cur_dir@@envvar(LIB_DIR)@@cpsep@@nfp(./nqp-runtime.jar)@@cpsep@@nfp(@envvar(JAR_DIR)@/@asmfile@)@@cpsep@@nfp(@envvar(JAR_DIR)@/@jlinefile@)@@cpsep@@nfp(@envvar(JAR_DIR)@/@jnafile@)@@cpsep@@nfp(@envvar(LIB_DIR)@/nqp.jar)@" -cp "@cur_dir@@envvar(LIB_DIR)@" nqp "@sh_allparams@"


### PR DESCRIPTION
Don't send it into gen/jvm but only use the `base_dir` to keep a single
copy of it. Still, not the best solution but we keep all the jars there
anyway for now.

#589 