### PR TITLE
Fix compiler warnings in main runner

### DIFF
--- a/src/vm/moar/runner/main.c
+++ b/src/vm/moar/runner/main.c
@@ -148,7 +148,9 @@ int wmain(int argc, wchar_t *wargv[])
 
     char   *exec_path;
     size_t  exec_path_size;
+#ifndef STATIC_EXEC_PATH
     int     res;
+#endif
 
     char   *exec_dir_path;
     char   *exec_dir_path_temp;

--- a/src/vm/moar/runner/main.c
+++ b/src/vm/moar/runner/main.c
@@ -179,8 +179,10 @@ int wmain(int argc, wchar_t *wargv[])
     int flag;
     int new_argc     = 0;
 
+#ifdef HAVE_TELEMEH
     unsigned int interval_id = 0;
     char telemeh_inited = 0;
+#endif
 
     MVMuint32 debugserverport = 0;
     int start_suspended = 0;

--- a/src/vm/moar/runner/main.c
+++ b/src/vm/moar/runner/main.c
@@ -158,10 +158,12 @@ int wmain(int argc, wchar_t *wargv[])
 
           char   *nqp_home;
           size_t  nqp_home_size;
+#ifndef STATIC_NQP_HOME
     const char    nqp_rel_path[14]    = "/../share/nqp";
     const size_t  nqp_rel_path_size   = 13;
     const char    nqp_check_path[28]  = "/lib/NQPCORE.setting.moarvm";
     const size_t  nqp_check_path_size = 27;
+#endif
 
     char *lib_path[1];
     char *nqp_file;

--- a/src/vm/moar/runner/main.c
+++ b/src/vm/moar/runner/main.c
@@ -152,9 +152,11 @@ int wmain(int argc, wchar_t *wargv[])
     int     res;
 #endif
 
-    char   *exec_dir_path;
     char   *exec_dir_path_temp;
+#ifndef STATIC_NQP_HOME
+    char   *exec_dir_path;
     size_t  exec_dir_path_size;
+#endif
 
           char   *nqp_home;
           size_t  nqp_home_size;
@@ -273,6 +275,12 @@ int wmain(int argc, wchar_t *wargv[])
     /* The +1 is the trailing \0 terminating the string. */
     exec_dir_path_temp = (char*)malloc(exec_path_size + 1);
     memcpy(exec_dir_path_temp, exec_path, exec_path_size + 1);
+
+    /* Retrieve NQP_HOME. */
+
+#ifdef STATIC_NQP_HOME
+    nqp_home = STRINGIFY(STATIC_NQP_HOME);
+#else
 #ifdef _WIN32
     PathRemoveFileSpecA(exec_dir_path_temp);
     exec_dir_path_size = strlen(exec_dir_path_temp);
@@ -282,12 +290,6 @@ int wmain(int argc, wchar_t *wargv[])
     exec_dir_path      = dirname(exec_dir_path_temp);
     exec_dir_path_size = strlen(exec_dir_path);
 #endif
-
-    /* Retrieve NQP_HOME. */
-
-#ifdef STATIC_NQP_HOME
-    nqp_home = STRINGIFY(STATIC_NQP_HOME);
-#else
     if (!retrieve_home(&nqp_home, nqp_rel_path, nqp_rel_path_size, "NQP_HOME",
             exec_dir_path, exec_dir_path_size, nqp_check_path, nqp_check_path_size)) {
         fprintf(stderr, "ERROR: NQP_HOME is invalid: %s\n", nqp_home);

--- a/src/vm/moar/runner/main.c
+++ b/src/vm/moar/runner/main.c
@@ -175,7 +175,7 @@ int wmain(int argc, wchar_t *wargv[])
     int flag;
     int new_argc     = 0;
 
-    unsigned int interval_id;
+    unsigned int interval_id = 0;
     char telemeh_inited = 0;
 
     MVMuint32 debugserverport = 0;


### PR DESCRIPTION
Now builds clean with `--relocatable` and without.