### PR TITLE
Fix for https://github.com/perl6/nqp/issues/559

### DIFF
--- a/src/QRegex/Cursor.nqp
+++ b/src/QRegex/Cursor.nqp
@@ -33,7 +33,7 @@ my class Braid is export {
 
     method !braid_init(:$grammar, :$actions, :$package, *%ignore) {
         my $new := nqp::create(self);
-        nqp::bindattr($new, Braid, '$!actions', $grammar);
+        nqp::bindattr($new, Braid, '$!grammar', $grammar);
         nqp::bindattr($new, Braid, '$!actions', $actions);
         nqp::bindattr($new, Braid, '$!package', $package);
         nqp::bindattr($new, Braid, '$!slangs', nqp::hash());


### PR DESCRIPTION
During timtoady's cleanup of the Braid API a copy paste error made
it through. This was discovered by cognomial++ some time ago.
This commit fixes the error where the Braid grammar class attribute
should have been initialized with a grammar instance.