### PR TITLE
More explicit error when more than one --target is provided (issue #600)

### DIFF
--- a/src/HLL/CommandLine.nqp
+++ b/src/HLL/CommandLine.nqp
@@ -231,6 +231,9 @@ class HLL::CommandLine::Parser {
                     if $opt eq 'profile-filename' {
                         note("--profile-filename is deprecated and will be removed in a future Rakudo release. Please use --profile=<filename> instead.");
                     }
+                    if $opt eq 'target' && nqp::existskey($result.options, 'target') {
+                        nqp::die("Multiple --target argument not allowed. Please give only one --target option");
+                    }
                     nqp::die("Illegal option --$opt") unless nqp::existskey(%!options, $opt);
                     nqp::die("Option --$opt does not allow a value") if !self.wants-value($opt) && $has-value;
                     if !$has-value && self.wants-value($opt) {


### PR DESCRIPTION
Fix: rakudo/rakudo#1464 <- prettify error message when 2 `--target` argument are provided
With a try catch, catching an impossible stringification of `%attribute<target>`

### Run

```sh
./install/bin/perl6 --target=parse --target=ast  < /dev/null
```

### Before
 
```text
Unhandled exception: cannot stringify this
   at gen/moar/stage2/NQPHLL.nqp:547  (/usr/share/nqp/lib/NQPHLL.moarvm:is_precomp_stage)
 from gen/moar/stage2/NQPHLL.nqp:1752  (/usr/share/nqp/lib/NQPHLL.moarvm:command_line)
 from gen/moar/main.nqp:54  (/usr/lib/perl6/runtime/perl6.moarvm:MAIN)
 from gen/moar/main.nqp:42  (/usr/lib/perl6/runtime/perl6.moarvm:<mainline>)
 from <unknown>:1  (/usr/lib/perl6/runtime/perl6.moarvm:<main>)
 from <unknown>:1  (/usr/lib/perl6/runtime/perl6.moarvm:<entry>)
```

### After

```text
Multiple --target argument not allowed. Please give only one --target option      
 [switches] [--] [programfile] [arguments]                                        
                                                                                  
With no arguments, enters a REPL (see --repl-mode option).                        
With a "[programfile]" or the "-e" option, compiles the given program             
and, by default, also executes the compiled code.                                 
                                                                                  
  -c                   check syntax only (runs BEGIN and CHECK blocks)            
  --doc                extract documentation and print it as text                 
.....
```

