### PR TITLE
Introduce VMNull on JVM backend

### DIFF
--- a/src/vm/jvm/runtime/org/perl6/nqp/io/AsyncProcessHandle.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/io/AsyncProcessHandle.java
@@ -59,40 +59,40 @@ public class AsyncProcessHandle implements IIOClosable {
                     int pid = (int)getPID(AsyncProcessHandle.this.proc);
 
                     SixModelObject ready = config.get("ready");
-                    if (ready != null) {
+                    if (Ops.isnull(ready) == 0) {
                         send(ready, null, boxInt(pid));
                     }
 
                     SixModelObject outputCallback = config.get("merge_bytes");
-                    if (outputCallback == null)
+                    if (Ops.isnull(outputCallback) == 1)
                         outputCallback = config.get("stdout_bytes");
-                    if (outputCallback != null)
+                    if (Ops.isnull(outputCallback) == 0)
                         launchReader(outputCallback, false);
 
                     SixModelObject errorCallback = config.get("stderr_bytes");
-                    if (errorCallback != null)
+                    if (Ops.isnull(errorCallback) == 0)
                         launchReader(errorCallback, true);
 
                     int outcome = AsyncProcessHandle.this.proc.waitFor();
                     SixModelObject done = config.get("done");
                     /* Return exit code left shifted by 8 for POSIX emulation. */
-                    if (done != null)
+                    if (Ops.isnull(done) == 0)
                         send(done, boxInt(outcome << 8));
                 }
                 catch (Throwable t) {
                     SixModelObject message = boxError(t.toString());
 
                     SixModelObject error = config.get("error");
-                    if (error != null)
+                    if (Ops.isnull(error) == 0)
                         send(error, message);
 
                     SixModelObject stdoutBytes = config.get("stdout_bytes");
-                    if (stdoutBytes != null)
+                    if (Ops.isnull(stdoutBytes) == 0)
                         send(stdoutBytes, AsyncProcessHandle.this.hllConfig.intBoxType,
                                 AsyncProcessHandle.this.hllConfig.strBoxType, message);
 
                     SixModelObject stderrBytes = config.get("stderr_bytes");
-                    if (stderrBytes != null)
+                    if (Ops.isnull(stderrBytes) == 0)
                         send(stderrBytes, AsyncProcessHandle.this.hllConfig.intBoxType,
                                 AsyncProcessHandle.this.hllConfig.strBoxType, message);
                 }
@@ -139,32 +139,32 @@ public class AsyncProcessHandle implements IIOClosable {
             Map<String, SixModelObject> config) {
         SixModelObject desc;
 
-        if (config.get("write") != null) {
+        if (Ops.isnull(config.get("write")) == 0) {
             pb.redirectInput(Redirect.PIPE);
         }
-        else if ((desc = config.get("stdin_fd")) != null) {
+        else if (Ops.isnull(desc = config.get("stdin_fd")) == 0) {
         }
         else {
             pb.redirectInput(Redirect.INHERIT);
         }
 
-        if (config.get("merge_bytes") != null) {
+        if (Ops.isnull(config.get("merge_bytes")) == 0) {
             pb.redirectOutput(Redirect.PIPE);
             pb.redirectErrorStream(true);
         }
         else {
-            if (config.get("stdout_bytes") != null) {
+            if (Ops.isnull(config.get("stdout_bytes")) == 0) {
                 pb.redirectOutput(Redirect.PIPE);
             }
-            else if ((desc = config.get("stdout_fd")) != null) {
+            else if (Ops.isnull(desc = config.get("stdout_fd")) == 0) {
             }
             else {
                 pb.redirectOutput(Redirect.INHERIT);
             }
-            if (config.get("stderr_bytes") != null) {
+            if (Ops.isnull(config.get("stderr_bytes")) == 0) {
                 pb.redirectError(Redirect.PIPE);
             }
-            else if ((desc = config.get("stderr_fd")) != null) {
+            else if (Ops.isnull(desc = config.get("stderr_fd")) == 0) {
             }
             else {
                 pb.redirectError(Redirect.INHERIT);

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/BootJavaInterop.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/BootJavaInterop.java
@@ -18,6 +18,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.perl6.nqp.runtime.Ops;
+
 import org.perl6.nqp.sixmodel.STable;
 import org.perl6.nqp.sixmodel.TypeObject;
 import org.perl6.nqp.sixmodel.SixModelObject;
@@ -260,7 +262,7 @@ public class BootJavaInterop {
 
         for (Iterator<Map.Entry<String, SixModelObject>> it = names.entrySet().iterator(); it.hasNext(); ) {
             Map.Entry<String, SixModelObject> ent = it.next();
-            if (ent.getValue() != null)
+            if (Ops.isnull(ent.getValue()) == 0)
                 hash.bind_key_boxed(tc, ent.getKey(), ent.getValue());
             else
                 it.remove();
@@ -905,7 +907,7 @@ public class BootJavaInterop {
 
         MethodVisitor mv = mc.mv;
         mv.visitVarInsn(Opcodes.ALOAD, mc.tcLoc);
-        if (invokee != null) {
+        if (Ops.isnull(invokee) == 0) {
             emitConst(mc, invokee, SixModelObject.class);
         } else {
             mv.visitVarInsn(Opcodes.ALOAD, 0);

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/CallFrame.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/CallFrame.java
@@ -181,7 +181,7 @@ public class CallFrame implements Cloneable {
             InvocationSpec is = sci.staticCode.st.InvocationSpec;
             if (is == null)
                 throw ExceptionHandling.dieInternal(tc, "Can not invoke this object");
-            if (is.ClassHandle != null)
+            if (Ops.isnull(is.ClassHandle) == 0)
                 this.codeRef = (CodeRef)sci.staticCode.get_attribute_boxed(tc, is.ClassHandle, is.AttrName, is.Hint);
             else
                 this.codeRef = (CodeRef)is.InvocationHandler;

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/ExceptionHandling.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/ExceptionHandling.java
@@ -207,7 +207,7 @@ all:
             tc.unwinder.unwindTarget = handlerInfo[0];
             tc.unwinder.unwindCompUnit = handlerFrame.codeRef.staticInfo.compUnit;
             tc.unwinder.category = category;
-            if (exObj != null)
+            if (Ops.isnull(exObj) == 0)
                 tc.unwinder.payload = (SixModelObject)exObj.payload;
             else
                 tc.unwinder.payload = null;
@@ -244,7 +244,7 @@ all:
             tc.unwinder.unwindTarget = handlerInfo[0];
             tc.unwinder.unwindCompUnit = handlerFrame.codeRef.staticInfo.compUnit;
             tc.unwinder.result = Ops.result_o(tc.curFrame);
-            if (exObj != null)
+            if (Ops.isnull(exObj) == 0)
                 tc.unwinder.payload = (SixModelObject)exObj.payload;
             throw tc.unwinder;
         default:
@@ -256,7 +256,7 @@ all:
     private static SixModelObject panic(ThreadContext tc, long category,
             VMExceptionInstance exObj) {
         StringBuilder message = new StringBuilder();
-        if (exObj != null && exObj.message != null)
+        if (Ops.isnull(exObj) == 0 && exObj.message != null)
             message.append("Unhandled exception: " + exObj.message + "\n");
         else
             message.append("Unhandled exception; category = " + category + "\n");

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/GlobalContext.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/GlobalContext.java
@@ -84,6 +84,11 @@ public class GlobalContext {
     public SixModelObject CallCapture;
 
      /**
+     * VMNull type; a basic, method-less type with the VMNull REPR.
+     */
+    public SixModelObject VMNull;
+
+     /**
      * Thread type; a basic, method-less type with the Thread REPR.
      */
     public SixModelObject Thread;

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/IOOps.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/IOOps.java
@@ -130,7 +130,7 @@ public final class IOOps {
 
     private static SixModelObject sigCache = null;
     public static SixModelObject getsignals(ThreadContext tc) {
-        if (sigCache != null) return sigCache;
+        if (Ops.isnull(sigCache) == 0) return sigCache;
 
         SixModelObject listType = tc.curFrame.codeRef.staticInfo.compUnit.hllConfig.listType;
         SixModelObject strType  = tc.curFrame.codeRef.staticInfo.compUnit.hllConfig.strBoxType;

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/IndyBootstrap.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/IndyBootstrap.java
@@ -70,7 +70,7 @@ public class IndyBootstrap {
     public static void subcallResolve_noa(Lookup caller, MutableCallSite cs, String name, int csIdx, ThreadContext tc, Object... args) {
         /* Locate the thing to call. */
         SixModelObject invokee = Ops.getlex(name, tc);
-        if (invokee == null)
+        if (Ops.isnull(invokee) == 1)
             throw ExceptionHandling.dieInternal(tc, "Can not invoke object '" + name + "'");
 
         /* Don't update callsite in cases where it's not safe. */
@@ -95,7 +95,7 @@ public class IndyBootstrap {
             InvocationSpec is = invokee.st.InvocationSpec;
             if (is == null)
                 throw ExceptionHandling.dieInternal(tc, "Can not invoke this object");
-            if (is.ClassHandle != null)
+            if (Ops.isnull(is.ClassHandle) == 0)
                 cr = (CodeRef)invokee.get_attribute_boxed(tc, is.ClassHandle, is.AttrName, is.Hint);
             else {
                 cr = (CodeRef)is.InvocationHandler;
@@ -139,7 +139,7 @@ public class IndyBootstrap {
 
     public static void subInvoker(MethodHandle mh, String name, CallSiteDescriptor csd, ThreadContext tc, Object[] args) throws Throwable {
         SixModelObject invokee = Ops.getlex(name, tc);
-        if (invokee == null)
+        if (Ops.isnull(invokee) == 1)
             throw ExceptionHandling.dieInternal(tc, "Can not invoke object '" + name + "'");
 
         CodeRef cr;
@@ -150,7 +150,7 @@ public class IndyBootstrap {
             InvocationSpec is = invokee.st.InvocationSpec;
             if (is == null)
                 throw ExceptionHandling.dieInternal(tc, "Can not invoke this object");
-            if (is.ClassHandle != null)
+            if (Ops.isnull(is.ClassHandle) == 0)
                 cr = (CodeRef)invokee.get_attribute_boxed(tc, is.ClassHandle, is.AttrName, is.Hint);
             else {
                 cr = (CodeRef)is.InvocationHandler;
@@ -189,7 +189,7 @@ public class IndyBootstrap {
     public static void subcallstaticResolve_noa(Lookup caller, MutableCallSite cs, String name, int csIdx, ThreadContext tc, Object... args) {
         /* Locate the thing to call. */
         SixModelObject invokee = Ops.getlex(name, tc);
-        if (invokee == null)
+        if (Ops.isnull(invokee) == 1)
             throw ExceptionHandling.dieInternal(tc, "Can not invoke object '" + name + "'");
 
         /* Don't update callsite in cases where it's not safe. */
@@ -214,7 +214,7 @@ public class IndyBootstrap {
             InvocationSpec is = invokee.st.InvocationSpec;
             if (is == null)
                 throw ExceptionHandling.dieInternal(tc, "Can not invoke this object");
-            if (is.ClassHandle != null)
+            if (Ops.isnull(is.ClassHandle) == 0)
                 cr = (CodeRef)invokee.get_attribute_boxed(tc, is.ClassHandle, is.AttrName, is.Hint);
             else {
                 cr = (CodeRef)is.InvocationHandler;
@@ -338,7 +338,7 @@ public class IndyBootstrap {
             InvocationSpec is = invokee.st.InvocationSpec;
             if (is == null)
                 throw ExceptionHandling.dieInternal(tc, "Can not invoke this object");
-            if (is.ClassHandle != null)
+            if (Ops.isnull(is.ClassHandle) == 0)
                 cr = (CodeRef)invokee.get_attribute_boxed(tc, is.ClassHandle, is.AttrName, is.Hint);
             else {
                 cr = (CodeRef)is.InvocationHandler;
@@ -405,7 +405,7 @@ public class IndyBootstrap {
             InvocationSpec is = invokee.st.InvocationSpec;
             if (is == null)
                 throw ExceptionHandling.dieInternal(tc, "Can not invoke this object");
-            if (is.ClassHandle != null)
+            if (Ops.isnull(is.ClassHandle) == 0)
                 cr = (CodeRef)invokee.get_attribute_boxed(tc, is.ClassHandle, is.AttrName, is.Hint);
             else {
                 cr = (CodeRef)is.InvocationHandler;
@@ -467,7 +467,7 @@ public class IndyBootstrap {
                 InvocationSpec is = invokee.st.InvocationSpec;
                 if (is == null)
                     throw ExceptionHandling.dieInternal(tc, "Can not invoke this object");
-                if (is.ClassHandle != null)
+                if (Ops.isnull(is.ClassHandle) == 0)
                     cr = (CodeRef)invokee.get_attribute_boxed(tc, is.ClassHandle, is.AttrName, is.Hint);
                 else {
                     cr = (CodeRef)is.InvocationHandler;
@@ -531,7 +531,7 @@ public class IndyBootstrap {
             InvocationSpec is = invokee.st.InvocationSpec;
             if (is == null)
                 throw ExceptionHandling.dieInternal(tc, "Can not invoke this object");
-            if (is.ClassHandle != null)
+            if (Ops.isnull(is.ClassHandle) == 0)
                 cr = (CodeRef)invokee.get_attribute_boxed(tc, is.ClassHandle, is.AttrName, is.Hint);
             else {
                 cr = (CodeRef)is.InvocationHandler;

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/NativeCallOps.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/NativeCallOps.java
@@ -383,7 +383,7 @@ public final class NativeCallOps {
         else {
             /* Handle mixins by following delegates. */
             if (target instanceof P6OpaqueBaseInstance
-            && ((P6OpaqueBaseInstance)target).delegate != null)
+            && (Ops.isnull(((P6OpaqueBaseInstance)target).delegate) == 0))
                 target = ((P6OpaqueBaseInstance)target).delegate;
             call = (NativeCallBody)target.get_boxing_of(tc, ncrepr.ID);
             if (call == null) {

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
@@ -2669,8 +2669,7 @@ public final class Ops {
     }
     public static SixModelObject createNull(ThreadContext tc) {
         SixModelObject vmnull = tc.gc.VMNull.st.REPR.allocate(tc, tc.gc.VMNull.st);
-        //return vmnull;
-        return null;
+        return vmnull;
     }
     public static long isnull(SixModelObject obj) {
         return obj == null || (obj.st != null && obj.st.REPR instanceof VMNull) ? 1 : 0;

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
@@ -2669,7 +2669,8 @@ public final class Ops {
     }
     public static SixModelObject createNull(ThreadContext tc) {
         SixModelObject vmnull = tc.gc.VMNull.st.REPR.allocate(tc, tc.gc.VMNull.st);
-        return vmnull;
+        //return vmnull;
+        return null;
     }
     public static long isnull(SixModelObject obj) {
         return obj == null ? 1 : 0;

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
@@ -139,6 +139,7 @@ import org.perl6.nqp.sixmodel.reprs.VMExceptionInstance;
 import org.perl6.nqp.sixmodel.reprs.VMHash;
 import org.perl6.nqp.sixmodel.reprs.VMHashInstance;
 import org.perl6.nqp.sixmodel.reprs.VMIterInstance;
+import org.perl6.nqp.sixmodel.reprs.VMNull;
 import org.perl6.nqp.sixmodel.reprs.VMThreadInstance;
 
 import sun.misc.Unsafe;
@@ -2666,8 +2667,13 @@ public final class Ops {
     public static long eqaddr(SixModelObject a, SixModelObject b) {
         return a == b ? 1 : 0;
     }
+    public static SixModelObject createNull(ThreadContext tc) {
+        SixModelObject vmnull = tc.gc.VMNull.st.REPR.allocate(tc, tc.gc.VMNull.st);
+        return vmnull;
+    }
     public static long isnull(SixModelObject obj) {
         return obj == null ? 1 : 0;
+        //return obj == null || (obj.st != null && obj.st.REPR instanceof VMNull) ? 1 : 0;
     }
     public static long isnull_s(String str) {
         return str == null ? 1 : 0;

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
@@ -1517,7 +1517,7 @@ public final class Ops {
     public static SixModelObject getlexref_i(ThreadContext tc, int idx) {
         CallFrame cf = tc.curFrame;
         SixModelObject refType = cf.codeRef.staticInfo.compUnit.hllConfig.intLexRef;
-        if (refType == null)
+        if (isnull(refType) == 1)
             throw ExceptionHandling.dieInternal(tc,
                 "No int lexical reference type registered for current HLL");
         NativeRefInstanceIntLex ref = (NativeRefInstanceIntLex)refType.st.REPR.allocate(tc, refType.st);
@@ -1528,7 +1528,7 @@ public final class Ops {
     public static SixModelObject getlexref_n(ThreadContext tc, int idx) {
         CallFrame cf = tc.curFrame;
         SixModelObject refType = cf.codeRef.staticInfo.compUnit.hllConfig.numLexRef;
-        if (refType == null)
+        if (isnull(refType) == 1)
             throw ExceptionHandling.dieInternal(tc,
                 "No num lexical reference type registered for current HLL");
         NativeRefInstanceNumLex ref = (NativeRefInstanceNumLex)refType.st.REPR.allocate(tc, refType.st);
@@ -1539,7 +1539,7 @@ public final class Ops {
     public static SixModelObject getlexref_s(ThreadContext tc, int idx) {
         CallFrame cf = tc.curFrame;
         SixModelObject refType = cf.codeRef.staticInfo.compUnit.hllConfig.strLexRef;
-        if (refType == null)
+        if (isnull(refType) == 1)
             throw ExceptionHandling.dieInternal(tc,
                 "No str lexical reference type registered for current HLL");
         NativeRefInstanceStrLex ref = (NativeRefInstanceStrLex)refType.st.REPR.allocate(tc, refType.st);
@@ -1550,7 +1550,7 @@ public final class Ops {
     public static SixModelObject getlexref_i_si(ThreadContext tc, int idx, int si) {
         CallFrame cf = tc.curFrame;
         SixModelObject refType = cf.codeRef.staticInfo.compUnit.hllConfig.intLexRef;
-        if (refType == null)
+        if (isnull(refType) == 1)
             throw ExceptionHandling.dieInternal(tc,
                 "No int lexical reference type registered for current HLL");
         while (si-- > 0)
@@ -1563,7 +1563,7 @@ public final class Ops {
     public static SixModelObject getlexref_n_si(ThreadContext tc, int idx, int si) {
         CallFrame cf = tc.curFrame;
         SixModelObject refType = cf.codeRef.staticInfo.compUnit.hllConfig.numLexRef;
-        if (refType == null)
+        if (isnull(refType) == 1)
             throw ExceptionHandling.dieInternal(tc,
                 "No num lexical reference type registered for current HLL");
         while (si-- > 0)
@@ -1576,7 +1576,7 @@ public final class Ops {
     public static SixModelObject getlexref_s_si(ThreadContext tc, int idx, int si) {
         CallFrame cf = tc.curFrame;
         SixModelObject refType = cf.codeRef.staticInfo.compUnit.hllConfig.strLexRef;
-        if (refType == null)
+        if (isnull(refType) == 1)
             throw ExceptionHandling.dieInternal(tc,
                 "No str lexical reference type registered for current HLL");
         while (si-- > 0)
@@ -1589,7 +1589,7 @@ public final class Ops {
     public static SixModelObject getlexref_i(String name, ThreadContext tc) {
         CallFrame cf = tc.curFrame;
         SixModelObject refType = cf.codeRef.staticInfo.compUnit.hllConfig.intLexRef;
-        if (refType == null)
+        if (isnull(refType) == 1)
             throw ExceptionHandling.dieInternal(tc,
                 "No int lexical reference type registered for current HLL");
         while (cf != null) {
@@ -1607,7 +1607,7 @@ public final class Ops {
     public static SixModelObject getlexref_n(String name, ThreadContext tc) {
         CallFrame cf = tc.curFrame;
         SixModelObject refType = cf.codeRef.staticInfo.compUnit.hllConfig.numLexRef;
-        if (refType == null)
+        if (isnull(refType) == 1)
             throw ExceptionHandling.dieInternal(tc,
                 "No num lexical reference type registered for current HLL");
         while (cf != null) {
@@ -1625,7 +1625,7 @@ public final class Ops {
     public static SixModelObject getlexref_s(String name, ThreadContext tc) {
         CallFrame cf = tc.curFrame;
         SixModelObject refType = cf.codeRef.staticInfo.compUnit.hllConfig.strLexRef;
-        if (refType == null)
+        if (isnull(refType) == 1)
             throw ExceptionHandling.dieInternal(tc,
                 "No str lexical reference type registered for current HLL");
         while (cf != null) {
@@ -2485,7 +2485,7 @@ public final class Ops {
             InvocationSpec is = invokee.st.InvocationSpec;
             if (is == null)
                 throw ExceptionHandling.dieInternal(tc, "Cannot invoke this object");
-            if (is.ClassHandle != null)
+            if (isnull(is.ClassHandle) == 0)
                 cr = (CodeRef)invokee.get_attribute_boxed(tc, is.ClassHandle, is.AttrName, is.Hint);
             else {
                 cr = (CodeRef)is.InvocationHandler;
@@ -2572,10 +2572,10 @@ public final class Ops {
         return obj.clone(tc);
     }
     public static long isconcrete(SixModelObject obj, ThreadContext tc) {
-        return obj == null || decont(obj, tc) instanceof TypeObject ? 0 : 1;
+        return isnull(obj) == 1 || decont(obj, tc) instanceof TypeObject ? 0 : 1;
     }
     public static long isconcrete_nd(SixModelObject obj, ThreadContext tc) {
-        return obj == null || obj instanceof TypeObject ? 0 : 1;
+        return isnull(obj) == 1 || obj instanceof TypeObject ? 0 : 1;
     }
     public static SixModelObject knowhow(ThreadContext tc) {
         return tc.gc.KnowHOW;
@@ -2614,25 +2614,25 @@ public final class Ops {
         return tc.curFrame.codeRef.staticInfo.compUnit.hllConfig.hashType;
     }
     public static SixModelObject findmethodInCache(ThreadContext tc, SixModelObject invocant, String name) {
-        if (invocant == null)
+        if (isnull(invocant) == 1)
             throw ExceptionHandling.dieInternal(tc, "Cannot call method '" + name + "' on a null object");
         invocant = decont(invocant, tc);
 
         SixModelObject meth = invocant.st.MethodCache.get(name);
-        if (meth == null)
+        if (isnull(meth) == 1)
             throw ExceptionHandling.dieInternal(tc,
                 "Method '" + name + "' not found for invocant of class '" + typeName(invocant, tc) + "'");
         return meth;
     }
     public static SixModelObject findmethod(SixModelObject invocant, String name, ThreadContext tc) {
         SixModelObject method = findmethodNonFatal(invocant, name, tc);
-        if (method == null)
+        if (isnull(method) == 1)
                 throw ExceptionHandling.dieInternal(tc,
                     "Method '" + name + "' not found for invocant of class '" + typeName(invocant, tc) + "'");
         return method;
     }
     public static SixModelObject findmethodNonFatal(SixModelObject invocant, String name, ThreadContext tc) {
-        if (invocant == null)
+        if (isnull(invocant) == 1)
             throw ExceptionHandling.dieInternal(tc, "Cannot call method '" + name + "' on a null object");
         invocant = decont(invocant, tc);
 
@@ -2641,7 +2641,7 @@ public final class Ops {
         /* Try the by-name method cache, if the HOW published one. */
         if (cache != null) {
             SixModelObject found = cache.get(name);
-            if (found != null)
+            if (isnull(found) == 0)
                 return found;
             if ((invocant.st.ModeFlags & STable.METHOD_CACHE_AUTHORITATIVE) != 0)
                 return null;
@@ -2662,7 +2662,7 @@ public final class Ops {
         return result_s(tc.curFrame);
     }
     public static long can(SixModelObject invocant, String name, ThreadContext tc) {
-        return findmethodNonFatal(invocant, name, tc) == null ? 0 : 1;
+        return isnull(findmethodNonFatal(invocant, name, tc)) == 1 ? 0 : 1;
     }
     public static long eqaddr(SixModelObject a, SixModelObject b) {
         return a == b ? 1 : 0;
@@ -2673,8 +2673,7 @@ public final class Ops {
         return null;
     }
     public static long isnull(SixModelObject obj) {
-        return obj == null ? 1 : 0;
-        //return obj == null || (obj.st != null && obj.st.REPR instanceof VMNull) ? 1 : 0;
+        return obj == null || (obj.st != null && obj.st.REPR instanceof VMNull) ? 1 : 0;
     }
     public static long isnull_s(String str) {
         return str == null ? 1 : 0;
@@ -2728,7 +2727,7 @@ public final class Ops {
         return obj;
     }
     public static long objprimspec(SixModelObject obj, ThreadContext tc) {
-        return obj == null ? 0 : obj.st.REPR.get_storage_spec(tc, obj.st).boxed_primitive;
+        return isnull(obj) == 1 ? 0 : obj.st.REPR.get_storage_spec(tc, obj.st).boxed_primitive;
     }
     public static SixModelObject setinvokespec(SixModelObject obj, SixModelObject ch,
             String name, SixModelObject invocationHandler, ThreadContext tc) {
@@ -2748,7 +2747,7 @@ public final class Ops {
     }
     public static long istype_nd(SixModelObject obj, SixModelObject type, ThreadContext tc) {
         /* Null always type checks false. */
-        if (obj == null)
+        if (isnull(obj) == 1)
             return 0;
 
         /* Start by considering cache. */
@@ -2771,7 +2770,7 @@ public final class Ops {
          * checking. */
         if (cache == null || (typeCheckMode & STable.TYPE_CHECK_CACHE_THEN_METHOD) != 0) {
             SixModelObject tcMeth = findmethodNonFatal(obj.st.HOW, "type_check", tc);
-            if (tcMeth == null)
+            if (isnull(tcMeth) == 1)
                 return 0;
                 /* TODO: Review why the following busts stuff. */
                 /*throw ExceptionHandling.dieInternal(tc,
@@ -2790,7 +2789,7 @@ public final class Ops {
         /* If the flag to call .accepts_type on the target value is set, do so. */
         if ((typeCheckMode & STable.TYPE_CHECK_NEEDS_ACCEPTS) != 0) {
             SixModelObject atMeth = findmethodNonFatal(type.st.HOW, "accepts_type", tc);
-            if (atMeth == null)
+            if (isnull(atMeth) == 1)
                 throw ExceptionHandling.dieInternal(tc,
                     "Expected accepts_type method, but none found in meta-object");
             invokeDirect(tc, atMeth, typeCheckCallSite, new Object[] { type.st.HOW, type, obj });
@@ -3072,7 +3071,7 @@ public final class Ops {
     /* Attribute reference operations. */
     public static SixModelObject getattrref_i(SixModelObject obj, SixModelObject ch, String name, ThreadContext tc) {
         SixModelObject refType = tc.curFrame.codeRef.staticInfo.compUnit.hllConfig.intAttrRef;
-        if (refType == null)
+        if (isnull(refType) == 1)
             throw ExceptionHandling.dieInternal(tc,
                 "No int attribute reference type registered for current HLL");
         NativeRefInstanceAttribute ref = (NativeRefInstanceAttribute)refType.st.REPR.allocate(tc, refType.st);
@@ -3084,7 +3083,7 @@ public final class Ops {
     }
     public static SixModelObject getattrref_n(SixModelObject obj, SixModelObject ch, String name, ThreadContext tc) {
         SixModelObject refType = tc.curFrame.codeRef.staticInfo.compUnit.hllConfig.numAttrRef;
-        if (refType == null)
+        if (isnull(refType) == 1)
             throw ExceptionHandling.dieInternal(tc,
                 "No num attribute reference type registered for current HLL");
         NativeRefInstanceAttribute ref = (NativeRefInstanceAttribute)refType.st.REPR.allocate(tc, refType.st);
@@ -3096,7 +3095,7 @@ public final class Ops {
     }
     public static SixModelObject getattrref_s(SixModelObject obj, SixModelObject ch, String name, ThreadContext tc) {
         SixModelObject refType = tc.curFrame.codeRef.staticInfo.compUnit.hllConfig.strAttrRef;
-        if (refType == null)
+        if (isnull(refType) == 1)
             throw ExceptionHandling.dieInternal(tc,
                 "No string attribute reference type registered for current HLL");
         NativeRefInstanceAttribute ref = (NativeRefInstanceAttribute)refType.st.REPR.allocate(tc, refType.st);
@@ -3426,7 +3425,7 @@ public final class Ops {
     /* Positional reference operations. */
     public static SixModelObject atposref_i(SixModelObject obj, long idx, ThreadContext tc) {
         SixModelObject refType = tc.curFrame.codeRef.staticInfo.compUnit.hllConfig.intPosRef;
-        if (refType == null)
+        if (isnull(refType) == 1)
             throw ExceptionHandling.dieInternal(tc,
                 "No int positional reference type registered for current HLL");
         NativeRefInstancePositional ref = (NativeRefInstancePositional)refType.st.REPR.allocate(tc, refType.st);
@@ -3436,7 +3435,7 @@ public final class Ops {
     }
     public static SixModelObject atposref_n(SixModelObject obj, long idx, ThreadContext tc) {
         SixModelObject refType = tc.curFrame.codeRef.staticInfo.compUnit.hllConfig.numPosRef;
-        if (refType == null)
+        if (isnull(refType) == 1)
             throw ExceptionHandling.dieInternal(tc,
                 "No num positional reference type registered for current HLL");
         NativeRefInstancePositional ref = (NativeRefInstancePositional)refType.st.REPR.allocate(tc, refType.st);
@@ -3446,7 +3445,7 @@ public final class Ops {
     }
     public static SixModelObject atposref_s(SixModelObject obj, long idx, ThreadContext tc) {
         SixModelObject refType = tc.curFrame.codeRef.staticInfo.compUnit.hllConfig.strPosRef;
-        if (refType == null)
+        if (isnull(refType) == 1)
             throw ExceptionHandling.dieInternal(tc,
                 "No string positional reference type registered for current HLL");
         NativeRefInstancePositional ref = (NativeRefInstancePositional)refType.st.REPR.allocate(tc, refType.st);
@@ -3458,7 +3457,7 @@ public final class Ops {
     /* Positional multidim reference operations. */
     public static SixModelObject multidimref_i(SixModelObject obj, SixModelObject indices, ThreadContext tc) {
         SixModelObject refType = tc.curFrame.codeRef.staticInfo.compUnit.hllConfig.intMultidimRef;
-        if (refType == null)
+        if (isnull(refType) == 1)
             throw ExceptionHandling.dieInternal(tc,
                 "No int multidim positional reference type registered for current HLL");
         NativeRefInstanceMultidim ref = (NativeRefInstanceMultidim)refType.st.REPR.allocate(tc, refType.st);
@@ -3469,7 +3468,7 @@ public final class Ops {
 
     public static SixModelObject multidimref_n(SixModelObject obj, SixModelObject indices, ThreadContext tc) {
         SixModelObject refType = tc.curFrame.codeRef.staticInfo.compUnit.hllConfig.numMultidimRef;
-        if (refType == null)
+        if (isnull(refType) == 1)
             throw ExceptionHandling.dieInternal(tc,
                 "No num multidim positional reference type registered for current HLL");
         NativeRefInstanceMultidim ref = (NativeRefInstanceMultidim)refType.st.REPR.allocate(tc, refType.st);
@@ -3480,7 +3479,7 @@ public final class Ops {
 
     public static SixModelObject multidimref_s(SixModelObject obj, SixModelObject indices, ThreadContext tc) {
         SixModelObject refType = tc.curFrame.codeRef.staticInfo.compUnit.hllConfig.strMultidimRef;
-        if (refType == null)
+        if (isnull(refType) == 1)
             throw ExceptionHandling.dieInternal(tc,
                 "No str multidim positional reference type registered for current HLL");
         NativeRefInstanceMultidim ref = (NativeRefInstanceMultidim)refType.st.REPR.allocate(tc, refType.st);
@@ -3592,10 +3591,10 @@ public final class Ops {
         return agg.exists_pos(tc, key);
     }
     public static long islist(SixModelObject obj, ThreadContext tc) {
-        return obj != null && obj.st.REPR instanceof VMArray ? 1 : 0;
+        return isnull(obj) == 0 && obj.st.REPR instanceof VMArray ? 1 : 0;
     }
     public static long ishash(SixModelObject obj, ThreadContext tc) {
-        return obj != null && obj.st.REPR instanceof VMHash ? 1 : 0;
+        return isnull(obj) == 0 && obj.st.REPR instanceof VMHash ? 1 : 0;
     }
 
     /* Parametricity operations. */
@@ -3702,10 +3701,10 @@ public final class Ops {
         return obj;
     }
     public static long iscont(SixModelObject obj) {
-        return obj == null || obj.st.ContainerSpec == null ? 0 : 1;
+        return isnull(obj) == 1 || obj.st.ContainerSpec == null ? 0 : 1;
     }
     public static long isrwcont(SixModelObject obj, ThreadContext tc) {
-        if (obj != null) {
+        if (isnull(obj) == 0) {
             ContainerSpec cs = obj.st.ContainerSpec;
             if (cs != null && cs.canStore(tc, obj))
                 return 1;
@@ -3713,7 +3712,7 @@ public final class Ops {
         return 0;
     }
     private static short getContainerPrimitive(SixModelObject obj) {
-        if (obj != null && !(obj instanceof TypeObject)) {
+        if (isnull(obj) == 0 && !(obj instanceof TypeObject)) {
             ContainerSpec cs = obj.st.ContainerSpec;
             if (cs instanceof NativeRefContainerSpec)
                 return ((NativeRefREPRData)(obj.st.REPRData)).primitive_type;
@@ -3730,7 +3729,7 @@ public final class Ops {
         return getContainerPrimitive(obj) == StorageSpec.BP_STR ? 1 : 0;
     }
     public static SixModelObject decont(SixModelObject obj, ThreadContext tc) {
-        if (obj == null)
+        if (isnull(obj) == 1)
             return null;
         ContainerSpec cs = obj.st.ContainerSpec;
         return cs == null || obj instanceof TypeObject ? obj : cs.fetch(tc, obj);
@@ -3887,7 +3886,7 @@ public final class Ops {
     }
     public static long istrue(SixModelObject obj, ThreadContext tc) {
         obj = decont(obj, tc);
-        if (obj == null) return 0;
+        if (isnull(obj) == 1) return 0;
         BoolificationSpec bs = obj.st.BoolificationSpec;
         switch (bs == null ? BoolificationSpec.MODE_NOT_TYPE_OBJECT : bs.Mode) {
         case BoolificationSpec.MODE_CALL_METHOD:
@@ -3934,7 +3933,7 @@ public final class Ops {
         obj = decont(obj, tc);
 
         // If it's null, it's "", 'cause that way we at least don't NPE.
-        if (obj == null)
+        if (isnull(obj) == 1)
             return "";
 
         // If it can unbox to a string, that wins right off.
@@ -3946,7 +3945,7 @@ public final class Ops {
         // We could put this in the generated code, but it's here to avoid the
         // bulk.
         SixModelObject numMeth = obj.st.MethodCache == null ? null : obj.st.MethodCache.get("Str");
-        if (numMeth != null) {
+        if (isnull(numMeth) == 0) {
             invokeDirect(tc, numMeth, invocantCallSite, new Object[] { obj });
             return result_s(tc.curFrame);
         }
@@ -3974,7 +3973,7 @@ public final class Ops {
         obj = decont(obj, tc);
 
         // If it's null, it's 0.0
-        if (obj == null)
+        if (isnull(obj) == 1)
             return 0.0;
 
         // If it can unbox as an int or a num, that wins right off.
@@ -3986,7 +3985,7 @@ public final class Ops {
 
         // Otherwise, look for a Num method.
         SixModelObject numMeth = obj.st.MethodCache.get("Num");
-        if (numMeth != null) {
+        if (isnull(numMeth) == 0) {
             invokeDirect(tc, numMeth, invocantCallSite, new Object[] { obj });
             return result_n(tc.curFrame);
         }
@@ -4008,7 +4007,7 @@ public final class Ops {
         obj = decont(obj, tc);
 
         // If it's null, it's 0
-        if (obj == null)
+        if (isnull(obj) == 1)
             return 0;
 
         // If it can unbox as an int or a num, that wins right off.
@@ -4020,7 +4019,7 @@ public final class Ops {
 
         // Otherwise, look for an Int method.
         SixModelObject intMeth = obj.st.MethodCache.get("Int");
-        if (intMeth != null) {
+        if (isnull(intMeth) == 0) {
             invokeDirect(tc, intMeth, invocantCallSite, new Object[] { obj });
             return result_i(tc.curFrame);
         }
@@ -5288,7 +5287,7 @@ public final class Ops {
         }
     }
     public static SixModelObject getobjsc(SixModelObject obj, ThreadContext tc) {
-        if (obj == null)
+        if (isnull(obj) == 1)
             return null;
         SerializationContext sc = obj.sc;
         if (sc == null)
@@ -5361,7 +5360,7 @@ public final class Ops {
             int crCount;
 
             CompilationUnit cu = tc.curFrame.codeRef.staticInfo.compUnit;
-            if (cr == null) {
+            if (isnull(cr) == 1) {
                 crArray = cu.qbidToCodeRef;
                 crCount = cu.serializedCodeRefCount();
             } else {
@@ -5447,7 +5446,7 @@ public final class Ops {
         /* See if the object is actually owned by another, and it's the
          * owner we need to repossess. */
         SixModelObject owner = obj.sc.owned_objects.get(obj);
-        if (owner != null)
+        if (isnull(owner) == 0)
             obj = owner;
 
         SerializationContext compSC = tc.compilingSCs.get(cscSize - 1).referencedSC;
@@ -5669,7 +5668,7 @@ public final class Ops {
             InvocationSpec is = dispFor.st.InvocationSpec;
             if (is == null)
                 throw ExceptionHandling.dieInternal(tc, "setdispatcherfor needs invokable target");
-                if (is.ClassHandle != null)
+                if (isnull(is.ClassHandle) == 0)
                     tc.currentDispatcherFor = (CodeRef)dispFor.get_attribute_boxed(tc,
                             is.ClassHandle, is.AttrName, is.Hint);
                 else
@@ -5678,8 +5677,8 @@ public final class Ops {
         return disp;
     }
     public static void takedispatcher(int lexIdx, ThreadContext tc) {
-        if (tc.currentDispatcher != null) {
-            if (tc.currentDispatcherFor == null ||
+        if (isnull(tc.currentDispatcher) == 0) {
+            if (isnull(tc.currentDispatcherFor) == 1 ||
                     tc.currentDispatcherFor == tc.curFrame.codeRef) {
                 tc.curFrame.oLex[lexIdx] = tc.currentDispatcher;
                 tc.currentDispatcher = null;
@@ -5695,7 +5694,7 @@ public final class Ops {
             InvocationSpec is = dispFor.st.InvocationSpec;
             if (is == null)
                 throw ExceptionHandling.dieInternal(tc, "setdispatcherfor needs invokable target");
-                if (is.ClassHandle != null)
+                if (isnull(is.ClassHandle) == 0)
                     tc.nextDispatcherFor = (CodeRef)dispFor.get_attribute_boxed(tc,
                             is.ClassHandle, is.AttrName, is.Hint);
                 else
@@ -5704,8 +5703,8 @@ public final class Ops {
         return disp;
     }
     public static void takenextdispatcher(int lexIdx, ThreadContext tc) {
-        if (tc.nextDispatcher != null) {
-            if (tc.nextDispatcherFor == null ||
+        if (isnull(tc.nextDispatcher) == 0) {
+            if (isnull(tc.nextDispatcherFor) == 1 ||
                     tc.nextDispatcherFor == tc.curFrame.codeRef) {
                 tc.curFrame.oLex[lexIdx] = tc.nextDispatcher;
                 tc.nextDispatcher = null;
@@ -5898,7 +5897,7 @@ public final class Ops {
 
     public static SixModelObject currentthread(ThreadContext tc) {
         SixModelObject thread = tc.VMThread;
-        if (thread == null) {
+        if (isnull(thread) == 1) {
             thread = tc.gc.Thread.st.REPR.allocate(tc, tc.gc.Thread.st);
             ((VMThreadInstance)thread).thread = Thread.currentThread();
             tc.VMThread = thread;
@@ -6487,14 +6486,14 @@ public final class Ops {
     }
     public static SixModelObject hllize(SixModelObject obj, ThreadContext tc) {
         HLLConfig wanted = tc.curFrame.codeRef.staticInfo.compUnit.hllConfig;
-        if (obj != null && obj.st.hllOwner == wanted)
+        if (isnull(obj) == 0 && obj.st.hllOwner == wanted)
             return obj;
         else
             return hllizeInternal(obj, wanted, tc);
     }
     public static SixModelObject hllizefor(SixModelObject obj, String language, ThreadContext tc) {
         HLLConfig wanted = tc.gc.getHLLConfigFor(language);
-        if (obj != null && obj.st.hllOwner == wanted)
+        if (isnull(obj) == 0 && obj.st.hllOwner == wanted)
             return obj;
         else
             return hllizeInternal(obj, wanted, tc);
@@ -6509,43 +6508,43 @@ public final class Ops {
     }
     private static SixModelObject hllizeInternal(SixModelObject obj, HLLConfig wanted, ThreadContext tc) {
         /* Map nulls to the language's designated null value. */
-        if (obj == null)
+        if (isnull(obj) == 1)
             return wanted.nullValue;
 
         /* Go by what role the object plays. */
         switch ((int)obj.st.hllRole) {
             case HLLConfig.ROLE_INT:
-                if (wanted.foreignTypeInt != null) {
+                if (isnull(wanted.foreignTypeInt) == 0) {
                     return box_i(obj.get_int(tc), wanted.foreignTypeInt, tc);
                 }
-                else if (wanted.foreignTransformInt != null) {
+                else if (isnull(wanted.foreignTransformInt) == 0) {
                     throw new RuntimeException("foreign_transform_int NYI");
                 }
                 else {
                     return obj;
                 }
             case HLLConfig.ROLE_NUM:
-                if (wanted.foreignTypeNum != null) {
+                if (isnull(wanted.foreignTypeNum) == 0) {
                     return box_n(obj.get_num(tc), wanted.foreignTypeNum, tc);
                 }
-                else if (wanted.foreignTransformNum != null) {
+                else if (isnull(wanted.foreignTransformNum) == 0) {
                     throw new RuntimeException("foreign_transform_num NYI");
                 }
                 else {
                     return obj;
                 }
             case HLLConfig.ROLE_STR:
-                if (wanted.foreignTypeStr != null) {
+                if (isnull(wanted.foreignTypeStr) == 0) {
                     return box_s(obj.get_str(tc), wanted.foreignTypeStr, tc);
                 }
-                else if (wanted.foreignTransformStr != null) {
+                else if (isnull(wanted.foreignTransformStr) == 0) {
                     throw new RuntimeException("foreign_transform_str NYI");
                 }
                 else {
                     return obj;
                 }
             case HLLConfig.ROLE_ARRAY:
-                if (wanted.foreignTransformArray != null) {
+                if (isnull(wanted.foreignTransformArray) == 0) {
                     invokeDirect(tc, wanted.foreignTransformArray,
                         invocantCallSite, new Object[] { obj });
                     return result_o(tc.curFrame);
@@ -6554,7 +6553,7 @@ public final class Ops {
                     return obj;
                 }
             case HLLConfig.ROLE_HASH:
-                if (wanted.foreignTransformHash != null) {
+                if (isnull(wanted.foreignTransformHash) == 0) {
                     invokeDirect(tc, wanted.foreignTransformHash,
                         invocantCallSite, new Object[] { obj });
                     return result_o(tc.curFrame);
@@ -6563,7 +6562,7 @@ public final class Ops {
                     return obj;
                 }
             case HLLConfig.ROLE_CODE:
-                if (wanted.foreignTransformCode != null) {
+                if (isnull(wanted.foreignTransformCode) == 0) {
                     invokeDirect(tc, wanted.foreignTransformCode,
                         invocantCallSite, new Object[] { obj });
                     return result_o(tc.curFrame);
@@ -6572,7 +6571,7 @@ public final class Ops {
                     return obj;
                 }
             default:
-                if (wanted.foreignTransformAny != null) {
+                if (isnull(wanted.foreignTransformAny) == 0) {
                     invokeDirect(tc, wanted.foreignTransformAny,
                         invocantCallSite, new Object[] { obj });
                     return result_o(tc.curFrame);
@@ -6663,7 +6662,7 @@ public final class Ops {
         int[] fates = runNFA(tc, (NFAInstance)nfa, target, pos);
 
         /* Push the results onto the bstack. */
-        long caps = cstack == null || cstack instanceof TypeObject ? 0 : cstack.elems(tc);
+        long caps = isnull(cstack) == 1 || cstack instanceof TypeObject ? 0 : cstack.elems(tc);
         for (int i = 0; i < fates.length; i++) {
             marks.at_pos_native(tc, fates[i]);
             bstack.push_native(tc);
@@ -7470,7 +7469,7 @@ public final class Ops {
             try {
                 if (resume != null) {
                     resume.resumeNext();
-                } else if (cont != null) {
+                } else if (isnull(cont) == 0) {
                     invokeDirect(tc, run, invocantCallSite, false, new Object[] { cont });
                 } else {
                     if (run instanceof ResumeStatus) {
@@ -7489,7 +7488,7 @@ public final class Ops {
                 // so we should just return.
                 return;
             } catch (SaveStackException sse) {
-                if (sse.key != null && sse.key != key) {
+                if (isnull(sse.key) == 0 && sse.key != key) {
                     // This is intended for an outer scope, so just append ourself
                     throw sse.pushFrame(0, reset_reenter, new Object[] { key }, null);
                 }

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/ResumeStatus.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/ResumeStatus.java
@@ -58,7 +58,7 @@ public class ResumeStatus extends SixModelObject {
             if (next != null) {
                 next.resume();
             } else {
-                if (thunk != null)
+                if (Ops.isnull(thunk) == 0)
                     Ops.invokeDirect(tc, thunk, Ops.emptyCallSite, false, Ops.emptyArgList);
             }
         }

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/CodePairContainerConfigurer.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/CodePairContainerConfigurer.java
@@ -1,6 +1,7 @@
 package org.perl6.nqp.sixmodel;
 
 import org.perl6.nqp.runtime.ExceptionHandling;
+import org.perl6.nqp.runtime.Ops;
 import org.perl6.nqp.runtime.ThreadContext;
 
 /**
@@ -17,11 +18,11 @@ public class CodePairContainerConfigurer extends ContainerConfigurer {
     public void configureContainerSpec(ThreadContext tc, STable st, SixModelObject config) {
         CodePairContainerSpec cs = (CodePairContainerSpec)st.ContainerSpec;
         SixModelObject fetch = config.at_key_boxed(tc, "fetch");
-        if (fetch == null)
+        if (Ops.isnull(fetch) == 1)
             throw ExceptionHandling.dieInternal(tc,
                 "Container spec 'code_pair' must be configured with a fetch");
         SixModelObject store = config.at_key_boxed(tc, "store");
-        if (store == null)
+        if (Ops.isnull(store) == 1)
             throw ExceptionHandling.dieInternal(tc,
                 "Container spec 'code_pair' must be configured with a store");
         cs.fetchCode = fetch;

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/KnowHOWBootstrapper.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/KnowHOWBootstrapper.java
@@ -28,6 +28,7 @@ public class KnowHOWBootstrapper {
         tc.gc.CallCapture = bootType(tc, "CallCapture", "CallCapture");
         tc.gc.BOOTException = bootType(tc, "BOOTException", "VMException");
         tc.gc.BOOTIO = bootType(tc, "BOOTIO", "IOHandle");
+        tc.gc.VMNull = bootType(tc, "VMNull", "VMNull");
         tc.gc.Thread = bootType(tc, "Thread", "VMThread");
 
         tc.gc.BOOTArray.st.hllRole = HLLConfig.ROLE_ARRAY;

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/KnowHOWMethods.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/KnowHOWMethods.java
@@ -32,7 +32,7 @@ public class KnowHOWMethods extends CompilationUnit {
             SixModelObject self = Ops.posparam_o(cf, csd, args, 0);
             String repr_arg = Ops.namedparam_opt_s(cf, csd, args, "repr");
             String name_arg = Ops.namedparam_opt_s(cf, csd, args, "name");
-            if (self == null || !(self.st.REPR instanceof KnowHOWREPR))
+            if (Ops.isnull(self) == 1 || !(self.st.REPR instanceof KnowHOWREPR))
                 throw ExceptionHandling.dieInternal(tc, "KnowHOW methods must be called on object with REPR KnowHOWREPR");
 
             /* We first create a new HOW instance. */
@@ -72,7 +72,7 @@ public class KnowHOWMethods extends CompilationUnit {
             String name = Ops.posparam_s(cf, csd, args, 2);
             SixModelObject method = Ops.posparam_o(cf, csd, args, 3);
 
-            if (self == null || !(self instanceof KnowHOWREPRInstance))
+            if (Ops.isnull(self) == 1 || !(self instanceof KnowHOWREPRInstance))
                 throw ExceptionHandling.dieInternal(tc, "KnowHOW methods must be called on object instance with REPR KnowHOWREPR");
 
             ((KnowHOWREPRInstance)self).methods.put(name, method);
@@ -92,9 +92,9 @@ public class KnowHOWMethods extends CompilationUnit {
             SixModelObject self = Ops.posparam_o(cf, csd, args, 0);
             SixModelObject attribute = Ops.posparam_o(cf, csd, args, 2);
 
-            if (self == null || !(self instanceof KnowHOWREPRInstance))
+            if (Ops.isnull(self) == 1 || !(self instanceof KnowHOWREPRInstance))
                 throw ExceptionHandling.dieInternal(tc, "KnowHOW methods must be called on object instance with REPR KnowHOWREPR");
-            if (attribute == null || !(attribute instanceof KnowHOWAttributeInstance))
+            if (Ops.isnull(attribute) == 1 || !(attribute instanceof KnowHOWAttributeInstance))
                 throw ExceptionHandling.dieInternal(tc, "KnowHOW attributes must use KnowHOWAttributeREPR");
 
             ((KnowHOWREPRInstance)self).attributes.add(attribute);
@@ -114,7 +114,7 @@ public class KnowHOWMethods extends CompilationUnit {
             SixModelObject self = Ops.posparam_o(cf, csd, args, 0);
             SixModelObject type_obj = Ops.posparam_o(cf, csd, args, 1);
 
-            if (self == null || !(self instanceof KnowHOWREPRInstance))
+            if (Ops.isnull(self) == 1 || !(self instanceof KnowHOWREPRInstance))
                 throw ExceptionHandling.dieInternal(tc, "KnowHOW methods must be called on object instance with REPR KnowHOWREPR");
 
             /* Set method cache. */
@@ -178,7 +178,7 @@ public class KnowHOWMethods extends CompilationUnit {
             args = tc.flatArgs;
             SixModelObject self = Ops.posparam_o(cf, csd, args, 0);
 
-            if (self == null || !(self instanceof KnowHOWREPRInstance))
+            if (Ops.isnull(self) == 1 || !(self instanceof KnowHOWREPRInstance))
                 throw ExceptionHandling.dieInternal(tc, "KnowHOW methods must be called on object instance with REPR KnowHOWREPR");
 
             SixModelObject BOOTArray = tc.gc.BOOTArray;
@@ -202,7 +202,7 @@ public class KnowHOWMethods extends CompilationUnit {
             args = tc.flatArgs;
             SixModelObject self = Ops.posparam_o(cf, csd, args, 0);
 
-            if (self == null || !(self instanceof KnowHOWREPRInstance))
+            if (Ops.isnull(self) == 1 || !(self instanceof KnowHOWREPRInstance))
                 throw ExceptionHandling.dieInternal(tc, "KnowHOW methods must be called on object instance with REPR KnowHOWREPR");
 
             SixModelObject BOOTHash = tc.gc.BOOTHash;
@@ -226,7 +226,7 @@ public class KnowHOWMethods extends CompilationUnit {
             args = tc.flatArgs;
             SixModelObject self = Ops.posparam_o(cf, csd, args, 0);
 
-            if (self == null || !(self instanceof KnowHOWREPRInstance))
+            if (Ops.isnull(self) == 1 || !(self instanceof KnowHOWREPRInstance))
                 throw ExceptionHandling.dieInternal(tc, "KnowHOW methods must be called on object instance with REPR KnowHOWREPR");
 
             Ops.return_s(((KnowHOWREPRInstance)self).name, cf);
@@ -253,7 +253,7 @@ public class KnowHOWMethods extends CompilationUnit {
 
             /* Populate it. */
             obj.name = name_arg;
-            obj.type = type_arg != null ? type_arg : tc.gc.KnowHOW;
+            obj.type = Ops.isnull(type_arg) == 0 ? type_arg : tc.gc.KnowHOW;
             obj.box_target = bt_arg == 0 ? 0 : 1;
 
             /* Return produced object. */

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/REPRRegistry.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/REPRRegistry.java
@@ -31,6 +31,7 @@ import org.perl6.nqp.sixmodel.reprs.VMArray;
 import org.perl6.nqp.sixmodel.reprs.VMException;
 import org.perl6.nqp.sixmodel.reprs.VMHash;
 import org.perl6.nqp.sixmodel.reprs.VMIter;
+import org.perl6.nqp.sixmodel.reprs.VMNull;
 import org.perl6.nqp.sixmodel.reprs.VMThread;
 import org.perl6.nqp.sixmodel.reprs.ReentrantMutex;
 import org.perl6.nqp.sixmodel.reprs.Semaphore;
@@ -95,6 +96,7 @@ public class REPRRegistry {
         addREPR("CStruct", new CStruct());
         addREPR("CPPStruct", new CPPStruct());
         addREPR("CUnion", new CUnion());
+        addREPR("VMNull", new VMNull());
         addREPR("VMThread", new VMThread());
         addREPR("ReentrantMutex", new ReentrantMutex());
         addREPR("Semaphore", new Semaphore());

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/SerializationReader.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/SerializationReader.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import org.perl6.nqp.runtime.CallFrame;
 import org.perl6.nqp.runtime.CodeRef;
+import org.perl6.nqp.runtime.Ops;
 import org.perl6.nqp.runtime.StaticCodeInfo;
 import org.perl6.nqp.runtime.ThreadContext;
 import org.perl6.nqp.sixmodel.reprs.VMHashInstance;
@@ -413,7 +414,7 @@ public class SerializationReader {
 
             /* Method cache and v-table. */
             SixModelObject methodCache = readRef();
-            if (methodCache != null)
+            if (Ops.isnull(methodCache) == 0)
                 st.MethodCache = ((VMHashInstance)methodCache).storage;
             st.VTable = new SixModelObject[(int)orig.getLong()];
             for (int j = 0; j < st.VTable.length; j++)
@@ -622,7 +623,7 @@ public class SerializationReader {
             elems = orig.getInt();
             for (int i = 0; i < elems; i++)
                 resArray.bind_pos_boxed(tc, i, readRef());
-            if (this.curObject != null) {
+            if (Ops.isnull(this.curObject) == 0) {
                 resArray.sc = sc;
                 sc.owned_objects.put(resArray, this.curObject);
             }
@@ -656,7 +657,7 @@ public class SerializationReader {
                 String key = lookupString(orig.getInt());
                 resHash.bind_key_boxed(tc, key, readRef());
             }
-            if (this.curObject != null) {
+            if (Ops.isnull(this.curObject) == 0) {
                 resHash.sc = sc;
                 sc.owned_objects.put(resHash, this.curObject);
             }

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/SerializationWriter.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/SerializationWriter.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import org.perl6.nqp.runtime.CallFrame;
 import org.perl6.nqp.runtime.CodeRef;
 import org.perl6.nqp.runtime.ExceptionHandling;
+import org.perl6.nqp.runtime.Ops;
 import org.perl6.nqp.runtime.ThreadContext;
 import org.perl6.nqp.sixmodel.reprs.CallCapture;
 import org.perl6.nqp.sixmodel.reprs.IOHandle;
@@ -295,7 +296,7 @@ public class SerializationWriter {
     public void writeRef(SixModelObject ref) {
         /* Work out what kind of thing we have and determine the discriminator. */
         short discrim = 0;
-        if (ref == null) {
+        if (Ops.isnull(ref) == 1) {
             discrim = REFVAR_VM_NULL;
         }
         else if (ref.st.REPR instanceof IOHandle) {
@@ -638,7 +639,7 @@ public class SerializationWriter {
 
     private SixModelObject closureToStaticCodeRef(CodeRef closure, boolean fatal) {
         SixModelObject staticCode = ((CodeRef)closure).staticInfo.staticCode;
-        if (staticCode == null)
+        if (Ops.isnull(staticCode) == 1)
         {
             if (fatal)
                 throw ExceptionHandling.dieInternal(tc,
@@ -711,7 +712,7 @@ public class SerializationWriter {
     private int getSerializedContextIdx(CallFrame cf) {
         if (cf.sc == null) {
             /* Make sure we should chase a level down. */
-            if (closureToStaticCodeRef(cf.codeRef, false) == null) {
+            if (Ops.isnull((SixModelObject)closureToStaticCodeRef(cf.codeRef, false)) == 1) {
                 return 0;
             }
             else {

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/CArray.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/CArray.java
@@ -42,12 +42,12 @@ public class CArray extends REPR {
         CArrayREPRData data = new CArrayREPRData();
 
         SixModelObject meth = Ops.findmethodNonFatal(st.WHAT, "of", tc);
-        if (meth == null)
+        if (Ops.isnull(meth) == 1)
             ExceptionHandling.dieInternal(tc, "CArray representation expects an 'of' method, specifying the element type");
 
         Ops.invokeDirect(tc, meth, new CallSiteDescriptor(new byte[] { ARG_OBJ }, null), new Object[] { st.WHAT });
         data.elem_type = Ops.decont(Ops.result_o(tc.resultFrame()), tc);
-        if (data.elem_type == null)
+        if (Ops.isnull(data.elem_type) == 1)
             ExceptionHandling.dieInternal(tc, "CArray representation expects a non-null return value from the 'of' method, specifying the element type");
 
         StorageSpec ss = data.elem_type.st.REPR.get_storage_spec(tc, data.elem_type.st);

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/CArrayInstance.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/CArrayInstance.java
@@ -83,7 +83,7 @@ public class CArrayInstance extends SixModelObject implements Refreshable {
         else if (index >= allocated)
             expand(tc, index+1);
 
-        if (child_objs[intidx] != null) {
+        if (Ops.isnull(child_objs[intidx]) == 0) {
             return child_objs[intidx];
         }
         else {
@@ -262,7 +262,7 @@ public class CArrayInstance extends SixModelObject implements Refreshable {
             SixModelObject child = child_objs[i];
 
             // No cache for this element? Go to next.
-            if (child == null) continue;
+            if (Ops.isnull(child) == 1) continue;
 
             /* Invalidate cache and recursively refresh child too. Future
              * versions here should only invalidate the cache if C memory has
@@ -281,7 +281,7 @@ public class CArrayInstance extends SixModelObject implements Refreshable {
             SixModelObject child = child_objs[i];
 
             // No cache for this element? Go to next.
-            if (child == null) continue;
+            if (Ops.isnull(child) == 1) continue;
 
             /* Invalidate cache. Future versions here should only invalidate
              * the cache if C memory has a different pointer than the cached

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/CPPStructInstance.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/CPPStructInstance.java
@@ -9,6 +9,7 @@ import com.sun.jna.Pointer;
 
 import org.perl6.nqp.runtime.ExceptionHandling;
 import org.perl6.nqp.runtime.NativeCallOps;
+import org.perl6.nqp.runtime.Ops;
 import org.perl6.nqp.runtime.ThreadContext;
 
 import org.perl6.nqp.sixmodel.SixModelObject;
@@ -83,7 +84,7 @@ public class CPPStructInstance extends SixModelObject implements Refreshable {
 
     public SixModelObject get_attribute_boxed(ThreadContext tc, SixModelObject class_handle, String name, long hint) {
         SixModelObject member = memberCache.get(name);
-        if (member != null) return member;
+        if (Ops.isnull(member) == 0) return member;
 
         CPPStructREPRData data = (CPPStructREPRData) class_handle.st.REPRData;
         AttrInfo info = data.fieldTypes.get(name);

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/CStructInstance.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/CStructInstance.java
@@ -9,6 +9,7 @@ import com.sun.jna.Pointer;
 
 import org.perl6.nqp.runtime.ExceptionHandling;
 import org.perl6.nqp.runtime.NativeCallOps;
+import org.perl6.nqp.runtime.Ops;
 import org.perl6.nqp.runtime.ThreadContext;
 
 import org.perl6.nqp.sixmodel.SixModelObject;
@@ -83,7 +84,7 @@ public class CStructInstance extends SixModelObject implements Refreshable {
 
     public SixModelObject get_attribute_boxed(ThreadContext tc, SixModelObject class_handle, String name, long hint) {
         SixModelObject member = memberCache.get(name);
-        if (member != null) return member;
+        if (Ops.isnull(member) == 0) return member;
 
         CStructREPRData data = (CStructREPRData) class_handle.st.REPRData;
         AttrInfo info = data.fieldTypes.get(name);

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/CUnionInstance.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/CUnionInstance.java
@@ -9,6 +9,7 @@ import com.sun.jna.Pointer;
 
 import org.perl6.nqp.runtime.ExceptionHandling;
 import org.perl6.nqp.runtime.NativeCallOps;
+import org.perl6.nqp.runtime.Ops;
 import org.perl6.nqp.runtime.ThreadContext;
 
 import org.perl6.nqp.sixmodel.SixModelObject;
@@ -83,7 +84,7 @@ public class CUnionInstance extends SixModelObject implements Refreshable {
 
     public SixModelObject get_attribute_boxed(ThreadContext tc, SixModelObject class_handle, String name, long hint) {
         SixModelObject member = memberCache.get(name);
-        if (member != null) return member;
+        if (Ops.isnull(member) == 0) return member;
 
         CUnionREPRData data = (CUnionREPRData) class_handle.st.REPRData;
         AttrInfo info = data.fieldTypes.get(name);

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/MultiCacheInstance.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/MultiCacheInstance.java
@@ -169,7 +169,7 @@ public class MultiCacheInstance extends SixModelObject {
         case CallSiteDescriptor.ARG_STR:
             return MD_CACHE_STR;
         case CallSiteDescriptor.ARG_OBJ:
-            if (arg == null)
+            if (Ops.isnull((SixModelObject)arg) == 1)
                 return MD_CACHE_NULL;
             SixModelObject cont = (SixModelObject)arg;
             SixModelObject decont = Ops.decont(cont, tc);

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/MultiDimArray.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/MultiDimArray.java
@@ -1,6 +1,7 @@
 package org.perl6.nqp.sixmodel.reprs;
 
 import org.perl6.nqp.runtime.ExceptionHandling;
+import org.perl6.nqp.runtime.Ops;
 import org.perl6.nqp.runtime.ThreadContext;
 import org.perl6.nqp.sixmodel.REPR;
 import org.perl6.nqp.sixmodel.STable;
@@ -69,11 +70,11 @@ public class MultiDimArray extends REPR {
 
     public void compose(ThreadContext tc, STable st, SixModelObject repr_info) {
         SixModelObject arrayInfo = repr_info.at_key_boxed(tc, "array");
-        if (arrayInfo != null) {
+        if (Ops.isnull(arrayInfo) == 0) {
             MultiDimArrayREPRData reprData = new MultiDimArrayREPRData();
 
             SixModelObject dims = arrayInfo.at_key_boxed(tc, "dimensions");
-            if (dims == null)
+            if (Ops.isnull(dims) == 1)
                  throw ExceptionHandling.dieInternal(tc,
                     "MultiDimArray REPR must be composed with a number of dimensions");
             int dimensions = (int)dims.get_int(tc);
@@ -83,7 +84,7 @@ public class MultiDimArray extends REPR {
             reprData.numDimensions = dimensions;
 
             SixModelObject type = arrayInfo.at_key_boxed(tc, "type");
-            StorageSpec ss = type != null ? type.st.REPR.get_storage_spec(tc, type.st) : null;
+            StorageSpec ss = Ops.isnull(type) == 0 ? type.st.REPR.get_storage_spec(tc, type.st) : null;
             switch (ss != null ? ss.boxed_primitive : StorageSpec.REFERENCE) {
             case StorageSpec.BP_INT:
             case StorageSpec.BP_NUM:
@@ -139,7 +140,7 @@ public class MultiDimArray extends REPR {
                 break;
             }
         }
-        if (obj == null)
+        if (Ops.isnull(obj) == 1)
             obj = new MultiDimArrayInstance();
         obj.st = st;
         return obj;
@@ -189,7 +190,7 @@ public class MultiDimArray extends REPR {
             MultiDimArrayREPRData reprData = new MultiDimArrayREPRData();
             reprData.numDimensions = dims;
             SixModelObject type = reader.readRef();
-            if (type != null) {
+            if (Ops.isnull(type) == 0) {
                 reprData.type = type;
                 reprData.ss = type.st.REPR.get_storage_spec(tc, type.st);
             }

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/NativeRef.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/NativeRef.java
@@ -1,6 +1,7 @@
 package org.perl6.nqp.sixmodel.reprs;
 
 import org.perl6.nqp.runtime.ExceptionHandling;
+import org.perl6.nqp.runtime.Ops;
 import org.perl6.nqp.runtime.ThreadContext;
 import org.perl6.nqp.sixmodel.REPR;
 import org.perl6.nqp.sixmodel.STable;
@@ -61,12 +62,12 @@ public class NativeRef extends REPR {
 
     public void compose(ThreadContext tc, STable st, SixModelObject repr_info) {
         SixModelObject info = repr_info.at_key_boxed(tc, "nativeref");
-        if (info != null) {
+        if (Ops.isnull(info) == 0) {
             SixModelObject type = info.at_key_boxed(tc, "type");
             short prim = type.st.REPR.get_storage_spec(tc, type.st).boxed_primitive;
             if (prim != StorageSpec.BP_NONE) {
                 SixModelObject refkind = info.at_key_boxed(tc, "refkind");
-                if (refkind != null) {
+                if (Ops.isnull(refkind) == 0) {
                     String refkind_s = refkind.get_str(tc);
                     NativeRefREPRData rd = new NativeRefREPRData();
                     if (refkind_s.equals("lexical")) {

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/P6OpaqueBaseInstance.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/P6OpaqueBaseInstance.java
@@ -1,4 +1,5 @@
 package org.perl6.nqp.sixmodel.reprs;
+import org.perl6.nqp.runtime.Ops;
 import org.perl6.nqp.runtime.ThreadContext;
 import org.perl6.nqp.sixmodel.STable;
 import org.perl6.nqp.sixmodel.SerializationReader;
@@ -39,7 +40,7 @@ public class P6OpaqueBaseInstance extends SixModelObject {
     public SixModelObject clone(ThreadContext tc) {
         try {
             SixModelObject cloned;
-            if (this.delegate != null)
+            if (Ops.isnull(this.delegate) == 0)
                 cloned = this.delegate.clone(tc);
             else
                 cloned = (SixModelObject)this.clone();
@@ -77,33 +78,33 @@ public class P6OpaqueBaseInstance extends SixModelObject {
 
     public SixModelObject get_attribute_boxed(ThreadContext tc, SixModelObject class_handle,
             String name, long hint) {
-        if (this.delegate != null)
+        if (Ops.isnull(this.delegate) == 0)
             return this.delegate.get_attribute_boxed(tc, class_handle, name, hint);
         else
             return super.get_attribute_boxed(tc, class_handle, name, hint);
     }
     public void get_attribute_native(ThreadContext tc, SixModelObject class_handle, String name, long hint) {
-        if (this.delegate != null)
+        if (Ops.isnull(this.delegate) == 0)
             this.delegate.get_attribute_native(tc, class_handle, name, hint);
         else
             super.get_attribute_native(tc, class_handle, name, hint);
     }
     public void bind_attribute_boxed(ThreadContext tc,SixModelObject class_handle,
             String name, long hint, SixModelObject value) {
-        if (this.delegate != null)
+        if (Ops.isnull(this.delegate) == 0)
             this.delegate.bind_attribute_boxed(tc, class_handle, name, hint, value);
         else
             super.bind_attribute_boxed(tc, class_handle, name, hint, value);
     }
     public void bind_attribute_native(ThreadContext tc,SixModelObject class_handle, String name, long hint) {
-        if (this.delegate != null)
+        if (Ops.isnull(this.delegate) == 0)
             this.delegate.bind_attribute_native(tc, class_handle, name, hint);
         else
             super.bind_attribute_native(tc, class_handle, name, hint);
     }
     public long is_attribute_initialized(ThreadContext tc, SixModelObject class_handle,
             String name, long hint) {
-        if (this.delegate != null)
+        if (Ops.isnull(this.delegate) == 0)
             return this.delegate.is_attribute_initialized(tc, class_handle, name, hint);
         else
             return super.is_attribute_initialized(tc, class_handle, name, hint);
@@ -155,13 +156,13 @@ public class P6OpaqueBaseInstance extends SixModelObject {
     }
 
     public SixModelObject posDelegate() {
-        if (this.delegate != null)
+        if (Ops.isnull(this.delegate) == 0)
             return ((P6OpaqueBaseInstance)this.delegate).posDelegate();
         throw new RuntimeException("This type does not support positional operations");
     }
 
     public SixModelObject assDelegate() {
-        if (this.delegate != null)
+        if (Ops.isnull(this.delegate) == 0)
             return ((P6OpaqueBaseInstance)this.delegate).assDelegate();
         throw new RuntimeException("This type does not support associative operations");
     }

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/P6int.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/P6int.java
@@ -5,6 +5,7 @@ import com.sun.jna.Native;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
+import org.perl6.nqp.runtime.Ops;
 import org.perl6.nqp.runtime.ThreadContext;
 import org.perl6.nqp.sixmodel.REPR;
 import org.perl6.nqp.sixmodel.STable;
@@ -45,9 +46,9 @@ public class P6int extends REPR {
 
     public void compose(ThreadContext tc, STable st, SixModelObject repr_info) {
         SixModelObject integerInfo = repr_info.at_key_boxed(tc, "integer");
-        if (integerInfo != null) {
+        if (Ops.isnull(integerInfo) == 0) {
             SixModelObject bits = integerInfo.at_key_boxed(tc, "bits");
-            if (bits != null) {
+            if (Ops.isnull(bits) == 0) {
                 short bitwidth = (short)bits.get_int(tc);
                 switch (bitwidth) {
                     case P6INT_C_TYPE_CHAR:
@@ -81,7 +82,7 @@ public class P6int extends REPR {
             }
 
             SixModelObject unsigned = integerInfo.at_key_boxed(tc, "unsigned");
-            if (unsigned != null)
+            if (Ops.isnull(unsigned) == 0)
                 ((StorageSpec)st.REPRData).is_unsigned = (short)unsigned.get_int(tc);
         }
     }

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/P6num.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/P6num.java
@@ -3,6 +3,7 @@ package org.perl6.nqp.sixmodel.reprs;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
+import org.perl6.nqp.runtime.Ops;
 import org.perl6.nqp.runtime.ThreadContext;
 import org.perl6.nqp.sixmodel.REPR;
 import org.perl6.nqp.sixmodel.STable;
@@ -38,9 +39,9 @@ public class P6num extends REPR {
 
     public void compose(ThreadContext tc, STable st, SixModelObject repr_info) {
         SixModelObject floatInfo = repr_info.at_key_boxed(tc, "float");
-        if (floatInfo != null) {
+        if (Ops.isnull(floatInfo) == 0) {
             SixModelObject bits = floatInfo.at_key_boxed(tc, "bits");
-            if (bits != null) {
+            if (Ops.isnull(bits) == 0) {
                 short bitwidth = (short)bits.get_int(tc);
                 switch (bitwidth) {
                     case P6NUM_C_TYPE_FLOAT:

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArray.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArray.java
@@ -1,6 +1,7 @@
 package org.perl6.nqp.sixmodel.reprs;
 
 import org.perl6.nqp.runtime.ExceptionHandling;
+import org.perl6.nqp.runtime.Ops;
 import org.perl6.nqp.runtime.ThreadContext;
 import org.perl6.nqp.sixmodel.REPR;
 import org.perl6.nqp.sixmodel.STable;
@@ -61,7 +62,7 @@ public class VMArray extends REPR {
 
     public void compose(ThreadContext tc, STable st, SixModelObject repr_info) {
         SixModelObject arrayInfo = repr_info.at_key_boxed(tc, "array");
-        if (arrayInfo != null) {
+        if (Ops.isnull(arrayInfo) == 0) {
             SixModelObject type = arrayInfo.at_key_boxed(tc, "type");
             StorageSpec ss = type.st.REPR.get_storage_spec(tc, type.st);
             switch (ss.boxed_primitive) {
@@ -198,7 +199,7 @@ public class VMArray extends REPR {
     {
         if (reader.version >= 7) {
             SixModelObject type = reader.readRef();
-            if (type != null) {
+            if (Ops.isnull(type) == 0) {
                 VMArrayREPRData reprData = new VMArrayREPRData();
                 reprData.type = type;
                 reprData.ss = type.st.REPR.get_storage_spec(tc, type.st);

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMArrayInstance.java
@@ -3,6 +3,7 @@ package org.perl6.nqp.sixmodel.reprs;
 import java.lang.System;
 
 import org.perl6.nqp.runtime.ExceptionHandling;
+import org.perl6.nqp.runtime.Ops;
 import org.perl6.nqp.runtime.ThreadContext;
 import org.perl6.nqp.sixmodel.SixModelObject;
 
@@ -34,7 +35,7 @@ public class VMArrayInstance extends VMArrayInstanceBase {
             key += this.elems;
         }
         if (key >= 0 && key < this.elems) {
-            return (this.slots[start + (int)key] != null) ? 1 : 0;
+            return (Ops.isnull(this.slots[start + (int)key]) == 0) ? 1 : 0;
         }
         return 0;
     }

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMNull.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMNull.java
@@ -1,0 +1,34 @@
+package org.perl6.nqp.sixmodel.reprs;
+
+import org.perl6.nqp.runtime.ExceptionHandling;
+import org.perl6.nqp.runtime.ThreadContext;
+import org.perl6.nqp.sixmodel.REPR;
+import org.perl6.nqp.sixmodel.STable;
+import org.perl6.nqp.sixmodel.SerializationReader;
+import org.perl6.nqp.sixmodel.SixModelObject;
+import org.perl6.nqp.sixmodel.TypeObject;
+
+public class VMNull extends REPR {
+    public SixModelObject type_object_for(ThreadContext tc, SixModelObject HOW) {
+        STable st = new STable(this, HOW);
+        SixModelObject obj = new TypeObject();
+        obj.st = st;
+        st.WHAT = obj;
+        return st.WHAT;
+    }
+
+    public SixModelObject allocate(ThreadContext tc, STable st) {
+        VMNullInstance obj = new VMNullInstance();
+        obj.st = st;
+        return obj;
+    }
+
+    public SixModelObject deserialize_stub(ThreadContext tc, STable st) {
+        throw ExceptionHandling.dieInternal(tc, "Cannot deserialize null");
+    }
+
+    public void deserialize_finish(ThreadContext tc, STable st,
+            SerializationReader reader, SixModelObject obj) {
+        throw ExceptionHandling.dieInternal(tc, "Cannot deserialize null");
+    }
+}

--- a/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMNullInstance.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/sixmodel/reprs/VMNullInstance.java
@@ -1,0 +1,6 @@
+package org.perl6.nqp.sixmodel.reprs;
+
+import org.perl6.nqp.sixmodel.SixModelObject;
+
+public class VMNullInstance extends SixModelObject {
+}


### PR DESCRIPTION
Again and again we have to add special cases in Rakudo for the JVM backend because ```nqp::null()``` creates a plain Java ```null``` whereas MoarVM has a concept of a VMNull.

The goal of this branch is to bring the JVM backend in line with MoarVM and let ```nqp::null()``` create a SixModelObject VMNull. In order to do that I changed ```isnull``` so that it checks for VMNull, too. Also, I've changed most of the ```null``` checks for SixModelObjects to use the pimped ```isnull``` instead.

I might have missed some ```null``` checks. Also, it could very well be the case that some of the changed checks shouldn't look for VMNull. But this branch passes all NQP tests (except some fudged tests) -- like current master does. Also, with some minor tweaks to JVM specific code in Rakudo, this branch seems to pass nearly all of the spectests working on NQP master.