### PR TITLE
Proof of concept bindings for fetch_delete_key and a regression test.

### DIFF
--- a/src/vm/moar/QAST/QASTOperationsMAST.nqp
+++ b/src/vm/moar/QAST/QASTOperationsMAST.nqp
@@ -2696,6 +2696,7 @@ QAST::MASTOperations.add_core_moarop_mapping('bindkey_n', 'bindkey_n', 2);
 QAST::MASTOperations.add_core_moarop_mapping('bindkey_s', 'bindkey_s', 2);
 QAST::MASTOperations.add_core_moarop_mapping('existskey', 'existskey');
 QAST::MASTOperations.add_core_moarop_mapping('deletekey', 'deletekey');
+QAST::MASTOperations.add_core_moarop_mapping('fetch_delete_key', 'fetch_delete_key');
 QAST::MASTOperations.add_core_moarop_mapping('elems', 'elems');
 QAST::MASTOperations.add_core_moarop_mapping('setelems', 'setelemspos', 0);
 QAST::MASTOperations.add_core_moarop_mapping('dimensions', 'dimensions');

--- a/t/nqp/108-vmhash.t
+++ b/t/nqp/108-vmhash.t
@@ -1,4 +1,4 @@
-plan(28);
+plan(41);
 
 my $backend := nqp::getcomp('nqp').backend.name;
 
@@ -100,3 +100,20 @@ $key := nqp::iterkey_s($iter);
 ok(nqp::existskey($hash, $key), 'second key from iterator exists');
 nqp::deletekey($hash, $key);
 ok(!nqp::existskey($hash, $key), 'second key from iterator no longer exists');
+is(nqp::elems($hash), 0, 'hash has no elements');
+
+$hash<a> := 1;
+$hash<b> := 2;
+is(nqp::elems($hash), 2, 'hash has 2 elements once more');
+ok(!nqp::defined(nqp::fetch_delete_key($hash, 'c')), 'key not found');
+is(nqp::elems($hash), 2, 'hash still has 2 elements');
+is(nqp::fetch_delete_key($hash, 'a'), 1, 'key is found');
+is(nqp::elems($hash), 1, 'key was deleted');
+ok(!nqp::existskey($hash, 'a'), 'key no longer exists');
+ok(nqp::existskey($hash, 'b'), 'second key still exists');
+ok(!nqp::defined(nqp::fetch_delete_key($hash, 'a')), 'key is gone');
+
+is(nqp::fetch_delete_key($hash, 'b'), 2, 'second key is found');
+is(nqp::elems($hash), 0, 'second key was deleted');
+ok(!nqp::existskey($hash, 'b'), 'second key no longer exists');
+ok(!nqp::defined(nqp::fetch_delete_key($hash, 'b')), 'second key is gone');


### PR DESCRIPTION
@lizmat - IIRC you said that a big annoyance with hashes was that to implement the Raku semantics on the API exposed by NQP, the code has to

1. fetch the value for the key
2. then delete the key
3. so that it can return the value

and quite often the value isn't even needed, but the implementation doesn't know that at the point that it's fetching it.

So, here's a proof of concept NQP op that can fetch and delete in one. I can do this bit easily. I can't do the "adapt Rakudo to use it".

Could you test using this in Rakudo to see how much it improves the relevant performance?

I didn't really want to bother @jnthn (or even $jnthn) with the "other" issues unless we know that it's something worth doing.

As best I can tell, other issues are

1. yet more C code in MoarVM, and I can't see an easy way to cleanly de-duplicate it. C doesn't have templates.
2. this name doesn't seem to fit the MoarVM op naming convention - what should it be?
3. this code is sort-of-bypassing the repr, so it's a bit of a hack (but it might be the leat hacky approach)
4. I implemented it by mostly copying `atkey_o` (so I don't know if I failed to spot something)
5. I did spot that `deletekey` has a serialisation barrier, so I added that, but I don't know what I missed
6. The JIT "implementation" is a blatant copy of `atkey_o` and might not even work. I think that I'm testing it, but I'm not certain.

Apart from all that, the test passes, and I know that it hits the relevant code - you'll need MoarVM/fetch-and-delete which is a branch off AAAA-A-better-hash. (I'll rebase it onto master once we merge tomorrow-ish)