### PR TITLE
Prove needs the nqp command prefixed with `./`

### DIFF
--- a/tools/templates/Makefile.in
+++ b/tools/templates/Makefile.in
@@ -19,7 +19,7 @@ qregex-test:@for_backends( @backend_prefix@-qregex-test)@
 @for_backends(@ctx_include(Makefile)@)@
 
 @nfp(t/*/*.t)@: all
-	$(PROVE) -r -v --exec @nfp(./nqp@bat@)@ $@
+	$(PROVE) -r -v --exec ./@nfp(./nqp@bat@)@ $@
 
 manifest:
 	echo MANIFEST >MANIFEST


### PR DESCRIPTION
Otherwise `make t/<test>/<file>.t` dies with:
Could not execute (nqp t/\<test\>/\<file\>.t): open3: exec of nqp t/\<test\>/\<file\>.t failed: No such file or directory at /usr/share/perl5/core_perl/TAP/Parser/Iterator/Process.pm line 165.