### PR TITLE
Fix all returned native integers getting treated as signed

### DIFF
--- a/src/vm/moar/QAST/QASTCompilerMAST.nqp
+++ b/src/vm/moar/QAST/QASTCompilerMAST.nqp
@@ -734,10 +734,10 @@ my class MASTCompilerInstance {
         'return_s',
         'return_o',
         '','','','','','','','',
-        'return_i', #FIXME need a return_u
-        'return_i',
-        'return_i',
-        'return_i'
+        'return_u',
+        'return_u',
+        'return_u',
+        'return_u'
     ];
 
     my @attr_opnames := [
@@ -1086,10 +1086,12 @@ my class MASTCompilerInstance {
                     $ins := self.coerce($ins, $MVM_reg_num64);
                 }
                 elsif $ins_result_kind == $MVM_reg_int32 || $ins_result_kind == $MVM_reg_int16 ||
-                        $ins_result_kind == $MVM_reg_int8 || $ins_result_kind == $MVM_reg_uint64 ||
-                        $ins_result_kind == $MVM_reg_uint32 || $ins_result_kind == $MVM_reg_uint16 ||
-                        $ins_result_kind == $MVM_reg_uint8 {
+                        $ins_result_kind == $MVM_reg_int8 {
                     $ins := self.coerce($ins, $MVM_reg_int64);
+                }
+                elsif $ins_result_kind == $MVM_reg_uint32 || $ins_result_kind == $MVM_reg_uint16 ||
+                        $ins_result_kind == $MVM_reg_uint8 {
+                    $ins := self.coerce($ins, $MVM_reg_uint64);
                 }
 
                 $block.return_kind($ins.result_kind);
@@ -1421,6 +1423,9 @@ my class MASTCompilerInstance {
         }
         elsif $result-kind == $MVM_reg_int64 {
             op_dispatch_i($!mast_frame, $result-reg, $disp-name, $callsite-id, [$code-reg]);
+        }
+        elsif $result-kind == $MVM_reg_uint64 {
+            op_dispatch_u($!mast_frame, $result-reg, $disp-name, $callsite-id, [$code-reg]);
         }
         elsif $result-kind == $MVM_reg_num64 {
             op_dispatch_n($!mast_frame, $result-reg, $disp-name, $callsite-id, [$code-reg]);

--- a/src/vm/moar/QAST/QASTOperationsMAST.nqp
+++ b/src/vm/moar/QAST/QASTOperationsMAST.nqp
@@ -2109,17 +2109,14 @@ QAST::MASTOperations.add_hll_unbox('', $MVM_reg_str, -> $qastcomp, $reg {
 QAST::MASTOperations.add_hll_unbox('', $MVM_reg_uint64, -> $qastcomp, $reg {
     my $regalloc := $qastcomp.regalloc;
     my $frame := $qastcomp.mast_frame;
-    my $tmp_reg := $regalloc.fresh_register($MVM_reg_int64);
     my $res_reg := $regalloc.fresh_register($MVM_reg_uint64);
     $regalloc.release_register($reg, $MVM_reg_obj);
     my $dc := $regalloc.fresh_register($MVM_reg_obj);
     op_decont($frame, $dc, $reg);
     my uint $callsite_id := $frame.callsites.get_callsite_id_from_args(
         $FAKE_OBJECT_ARG, [MAST::InstructionList.new($dc, $MVM_reg_obj)]);
-    op_dispatch_i($frame, $tmp_reg, 'nqp-uintify', $callsite_id, [$dc]);
+    op_dispatch_u($frame, $res_reg, 'nqp-uintify', $callsite_id, [$dc]);
     $regalloc.release_register($dc, $MVM_reg_obj);
-    %core_op_generators{'coerce_iu'}($frame, $res_reg, $tmp_reg);
-    $regalloc.release_register($tmp_reg, $MVM_reg_int64);
     MAST::InstructionList.new($res_reg, $MVM_reg_uint64)
 });
 sub boxer($kind, $type_op, $op) {

--- a/src/vm/moar/QAST/QASTRegexCompilerMAST.nqp
+++ b/src/vm/moar/QAST/QASTRegexCompilerMAST.nqp
@@ -56,6 +56,7 @@ my %core_op_generators := MAST::Ops.WHO<%generators>;
 
 my &op_dispatch_v := %core_op_generators<dispatch_v>;
 my &op_dispatch_i := %core_op_generators<dispatch_i>;
+my &op_dispatch_u := %core_op_generators<dispatch_u>;
 my &op_dispatch_n := %core_op_generators<dispatch_n>;
 my &op_dispatch_s := %core_op_generators<dispatch_s>;
 my &op_dispatch_o := %core_op_generators<dispatch_o>;
@@ -78,7 +79,7 @@ sub emit_dispatch_instruction($qastcomp, str $dispatcher_name, uint $callsite_id
             $res_reg := $qastcomp.regalloc.fresh_register($res_kind);
             op_dispatch_o($frame, $res_reg, $dispatcher_name, $callsite_id, @arg_idxs);
         }
-        elsif $primspec == 1 || $primspec == 10 {
+        elsif $primspec == 1 {
             if $res_kind == $MVM_reg_int64 {
                 $res_reg := $qastcomp.regalloc.fresh_register($res_kind);
                 op_dispatch_i($frame, $res_reg, $dispatcher_name, $callsite_id, @arg_idxs);
@@ -88,6 +89,18 @@ sub emit_dispatch_instruction($qastcomp, str $dispatcher_name, uint $callsite_id
                 op_dispatch_i($frame, $temp_reg, $dispatcher_name, $callsite_id, @arg_idxs);
                 $res_reg := $qastcomp.coerce(
                     MAST::InstructionList.new($temp_reg, $MVM_reg_int64), $res_kind).result_reg;
+            }
+        }
+        elsif $primspec == 10 {
+            if $res_kind == $MVM_reg_uint64 {
+                $res_reg := $qastcomp.regalloc.fresh_register($res_kind);
+                op_dispatch_u($frame, $res_reg, $dispatcher_name, $callsite_id, @arg_idxs);
+            }
+            else {
+                my $temp_reg := $qastcomp.regalloc.fresh_register($MVM_reg_uint64);
+                op_dispatch_u($frame, $temp_reg, $dispatcher_name, $callsite_id, @arg_idxs);
+                $res_reg := $qastcomp.coerce(
+                    MAST::InstructionList.new($temp_reg, $MVM_reg_uint64), $res_kind).result_reg;
             }
         }
         elsif $primspec == 2 {


### PR DESCRIPTION
Use the new ops for dispatching with unsigned result and returning native
unsinged integers on MoarVM