### PR TITLE
Use new MacOS and Ubuntu versions in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,38 +44,38 @@ stages:
            MOAR_OPTIONS: '--relocatable'
 
          Mac_MVM:
-           IMAGE_NAME: 'macOS-12'
+           IMAGE_NAME: 'macOS-15'
            RAKUDO_OPTIONS: ''
            NQP_OPTIONS: '--backends=moar'
            MOAR_OPTIONS: ''
          Mac_JVM:
-           IMAGE_NAME: 'macOS-12'
+           IMAGE_NAME: 'macOS-15'
            BACKEND: 'JVM'
            MOAR_CHECKOUT_TYPE: 'none'
            RAKUDO_OPTIONS: ''
            NQP_OPTIONS: '--backends=jvm'
            MOAR_OPTIONS: ''
          Mac_MVM_reloc:
-           IMAGE_NAME: 'macOS-12'
+           IMAGE_NAME: 'macOS-15'
            RELOCATABLE: 'yes'
            RAKUDO_OPTIONS: '--relocatable'
            NQP_OPTIONS: '--backends=moar --relocatable'
            MOAR_OPTIONS: '--relocatable'
 
          Lin_MVM:
-           IMAGE_NAME: 'ubuntu-20.04'
+           IMAGE_NAME: 'ubuntu-24.04'
            RAKUDO_OPTIONS: ''
            NQP_OPTIONS: '--backends=moar'
            MOAR_OPTIONS: ''
          Lin_JVM:
-           IMAGE_NAME: 'ubuntu-20.04'
+           IMAGE_NAME: 'ubuntu-24.04'
            BACKEND: 'JVM'
            MOAR_CHECKOUT_TYPE: 'none'
            RAKUDO_OPTIONS: ''
            NQP_OPTIONS: '--backends=jvm'
            MOAR_OPTIONS: ''
          Lin_MVM_reloc:
-           IMAGE_NAME: 'ubuntu-20.04'
+           IMAGE_NAME: 'ubuntu-24.04'
            RELOCATABLE: 'yes'
            RAKUDO_OPTIONS: '--relocatable'
            NQP_OPTIONS: '--backends=moar --relocatable'


### PR DESCRIPTION
MoarVM and Rakudo have more combinations of older and newer versions, but NQP sees fewer changes, so it's probably not as important to try everything.