### PR TITLE
Transform comp_line_directives from an AoS to a SoA

### DIFF
--- a/src/HLL/Actions.nqp
+++ b/src/HLL/Actions.nqp
@@ -265,6 +265,6 @@ class HLL::Actions {
 
     method comment:sym<line_directive>($/) {
         my $orig_line := HLL::Compiler.lineof($/.orig(), $/.from(), :cache(1), :directives(0));
-        $*W.add_comp_line_directive([$orig_line, nqp::radix(10, $<line>, 0, 0)[0], $<filename>]);
+        $*W.add_comp_line_directive($orig_line, nqp::radix(10, $<line>, 0, 0)[0], ~$<filename>);
     }
 }

--- a/src/HLL/Compiler.nqp
+++ b/src/HLL/Compiler.nqp
@@ -304,7 +304,7 @@ class HLL::Compiler does HLL::Backend::Default {
                                      || %adverbs<show-config>;
         self.nqpevent(%adverbs<nqpevent>) if %adverbs<nqpevent>;
 
-        my @*comp_line_directives;
+        my @*comp_line_directives := [nqp::list_i(), nqp::list_i(), nqp::list_s()];
         my $result;
         my $error;
         my $has_error := 0;
@@ -762,16 +762,17 @@ class HLL::Compiler does HLL::Backend::Default {
         my str $file := '';
         if $directives {
             my @clds := @*comp_line_directives;
-            my int $i := nqp::elems(@clds);
+            my $cld_linenos := @clds[0];
+            my int $i := nqp::elems($cld_linenos);
             if $i {
                 while $i > 0 {
                     $i := $i - 1;
-                    last if $line > @clds[$i][0];
+                    last if $line > nqp::atpos_i($cld_linenos, $i);
                 }
-                if $line > @clds[$i][0] {
-                    my @directive := @clds[$i];
-                    $line := $line - @directive[0] + @directive[1] - 1;
-                    $file := @directive[2];
+
+                if $line > nqp::atpos_i($cld_linenos, $i) {
+                    $line := $line - nqp::atpos_i(@clds[0], $i) + nqp::atpos_i(@clds[1], $i) - 1;
+                    $file := nqp::atpos_s(@clds[2], $i);
                 }
             }
         }

--- a/src/HLL/World.nqp
+++ b/src/HLL/World.nqp
@@ -187,11 +187,13 @@ class HLL::World {
         $!context.fixup_tasks
     }
 
-    method add_comp_line_directive(@directive) {
+    method add_comp_line_directive(int $orig-line, int $mapped-line, str $filename) {
         my @clds := @*comp_line_directives;
-        my int $elems := nqp::elems(@clds);
-        if $elems == 0 || !(@clds[$elems - 1][0] eq @directive[0]) {
-            nqp::push(@clds, @directive);
+        my int $elems := nqp::elems(@clds[0]);
+        if $elems == 0 || !(nqp::atpos_i(@clds[0], $elems - 1) != $orig-line) {
+            nqp::push_i(@clds[0], $orig-line);
+            nqp::push_i(@clds[1], $mapped-line);
+            nqp::push_s(@clds[2], $filename);
         }
     }
 


### PR DESCRIPTION
Instead of having an object array with many three-element obj-arrays in it, have two int-arrays and a str-array.

This removes one indirection from line number lookup when searching through the array of comp line directives. Also, this should use less memory at compile time.

This rarely matters very much, except for the generated RakuAST source file that is concatenated into the BOOTSTRAP/v6c.nqp file, which has multiple thousand comp_line_directives and compiling the v6c bootstrap used to spend almost 10% of its time inside method linefileof.

A side-effect of this change is that we now store only a string instead of the whole match object for the filename inside the comp line directives array, which I expect only has a very minor impact on anything.

(SoA means Struct of Array and AoS means Array of Struct. Technically, this was an AoA and turned into a different kind of AoA, but the smaller arrays were always constant-length and each slot had a specified meaning, just like members of a struct, so I think it makes sense to call it that)