### PR TITLE
Fix lookbehind for patterns that cannot be flipped

### DIFF
--- a/src/NQP/Actions.nqp
+++ b/src/NQP/Actions.nqp
@@ -1925,8 +1925,12 @@ class NQP::RegexActions is QRegex::P6Regex::Actions {
                         $qast[0].push(self.qbuildsub($<nibbler>.ast, :anon(1), :addself(1)));
                         $qast[0].push(QAST::IVal.new( :value($litlen) ));  # optional offset to before
                     }
-                    else {
+                    elsif self.can_flip_ast($<nibbler>.ast) {
                         $qast[0].push(self.qbuildsub(self.flip_ast($<nibbler>.ast), :anon(1), :addself(1)));
+                    }
+                    else {
+                        $qast[0][0].value('after_scan');
+                        $qast[0].push(self.qbuildsub($<nibbler>.ast, :anon(1), :addself(1)));
                     }
                 }
                 else {

--- a/src/QRegex/Cursor.nqp
+++ b/src/QRegex/Cursor.nqp
@@ -1132,16 +1132,70 @@ role NQPMatchRole is export {
         ) if nqp::isnull_s($flipped);
 
         # Set up cursor with  updated shared info with flipped string
-        my $cursor := self."!cursor_start_cur"();
+        my $flipped_cursor := self."!cursor_start_cur"();
         my $cursor_shared := nqp::clone($shared);
         nqp::bindattr_s($cursor_shared,ParseShared,'$!target', $flipped);
-        nqp::bindattr($cursor, $?CLASS, '$!shared', $cursor_shared);
+        nqp::bindattr($flipped_cursor, $?CLASS, '$!shared', $cursor_shared);
 
         # Update positions to match flipped
         my int $cursor_pos := nqp::chars($flipped) - $pos;
-        nqp::bindattr_i($cursor, $?CLASS, '$!from', $cursor_pos);
-        nqp::bindattr_i($cursor, $?CLASS, '$!pos',  $cursor_pos);
-        nqp::getattr_i($regex($cursor), $?CLASS, '$!pos') >= 0
+        nqp::bindattr_i($flipped_cursor, $?CLASS, '$!from', $cursor_pos);
+        nqp::bindattr_i($flipped_cursor, $?CLASS, '$!pos',  $cursor_pos);
+
+        # Pass or fail on a cursor of our own, not the one the regex ran
+        # on: that one holds the flipped target and flipped positions.
+        my $cursor := self."!cursor_start_cur"();
+        nqp::getattr_i($regex($flipped_cursor), $?CLASS, '$!pos') >= 0
+          ?? $cursor."!cursor_pass"($pos, 'after')
+          !! nqp::bindattr_i($cursor, $?CLASS, '$!pos', -3);
+
+        # Restore expectations
+        nqp::bindattr_i($shared, ParseShared, '$!highwater',  $orig_highwater);
+        nqp::bindattr(  $shared, ParseShared, '@!highexpect', $orig_highexpect);
+
+        $cursor
+    }
+
+    # Lookbehind for patterns that cannot be matched on the flipped
+    # target, such as subrule calls, whose compiled bodies match
+    # left-to-right no matter what called them.  Matches the unmodified
+    # pattern forward from each position at or before the current one,
+    # succeeding if any such match ends exactly at the current position.
+    method after_scan($regex) {
+        my $*SUPPOSING         := 1;
+
+        my $shared  := $!shared;
+        my int $pos := $!pos;
+
+        # Save and clear current expectations
+        my int $orig_highwater :=
+          nqp::getattr_i($shared, ParseShared, '$!highwater');
+        my $orig_highexpect :=
+          nqp::getattr($shared, ParseShared, '@!highexpect');
+        nqp::bindattr($shared, ParseShared, '@!highexpect', nqp::list_s);
+
+        my $cursor := self."!cursor_start_cur"();
+
+        my int $found := 0;
+        my int $start := $pos;
+        while $start >= 0 && !$found {
+            my $try := self."!cursor_start_cur"();
+            nqp::bindattr_i($try, $?CLASS, '$!from', $start);
+            nqp::bindattr_i($try, $?CLASS, '$!pos',  $start);
+            my $match   := $regex($try);
+            my int $end := nqp::getattr_i($match, $?CLASS, '$!pos');
+
+            # A match that ends elsewhere is backtracked into, in case
+            # another way it can match does end at the right position.
+            while $end >= 0 && $end != $pos {
+                $match := $match."!cursor_next"();
+                $end   := nqp::getattr_i($match, $?CLASS, '$!pos');
+            }
+            $found := 1 if $end == $pos;
+            $start := $start - 1;
+        }
+
+        $found
           ?? $cursor."!cursor_pass"($pos, 'after')
           !! nqp::bindattr_i($cursor, $?CLASS, '$!pos', -3);
 

--- a/src/QRegex/P5Regex/Actions.nqp
+++ b/src/QRegex/P5Regex/Actions.nqp
@@ -270,12 +270,16 @@ class QRegex::P5Regex::Actions is HLL::Actions {
 
     method p5assertion:sym«<»($/) {
         if $<nibbler> {
+            my $lookbehind := self.can_flip_ast($<nibbler>.ast)
+                ?? QAST::NodeList.new(
+                       QAST::SVal.new( :value('after') ),
+                       self.qbuildsub(self.flip_ast($<nibbler>.ast), :anon(1), :addself(1)))
+                !! QAST::NodeList.new(
+                       QAST::SVal.new( :value('after_scan') ),
+                       self.qbuildsub($<nibbler>.ast, :anon(1), :addself(1)));
             make QAST::Regex.new(
                 :rxtype<subrule>, :subtype<zerowidth>, :negate($<neg> eq '!'), :node($/),
-                QAST::NodeList.new(
-                    QAST::SVal.new( :value('after') ),
-                    self.qbuildsub(self.flip_ast($<nibbler>.ast), :anon(1), :addself(1))
-                ));
+                $lookbehind);
         }
         else {
             make 0;
@@ -447,6 +451,32 @@ class QRegex::P5Regex::Actions is HLL::Actions {
         nqp::deletekey(%capnames, '$!from');
         nqp::deletekey(%capnames, '$!to');
         %capnames;
+    }
+
+    # Whether flip_ast can turn this syntax tree into one that, matched
+    # against the flipped target, is equivalent to matching the original
+    # right-to-left.  It only reverses literals and concat order, so
+    # anything else that is direction-sensitive (subrule calls such as
+    # backreferences, zero-width checks, and anchors, which it does not
+    # swap) forces the lookbehind to scan instead.
+    method can_flip_ast($qast) {
+        return 1 unless nqp::istype($qast, QAST::Regex);
+        return 0 if $qast.subtype eq 'zerowidth';
+        my $rxtype := $qast.rxtype;
+        if $rxtype eq 'literal' || $rxtype eq 'cclass'
+          || $rxtype eq 'enumcharlist' || $rxtype eq 'charrange' {
+            1
+        }
+        elsif $rxtype eq 'concat' || $rxtype eq 'alt' || $rxtype eq 'altseq'
+          || $rxtype eq 'quant' {
+            for @($qast) {
+                return 0 unless self.can_flip_ast($_);
+            }
+            1
+        }
+        else {
+            0
+        }
     }
 
     method flip_ast($qast) {
@@ -647,9 +677,18 @@ class QRegex::P5Regex::Actions is HLL::Actions {
                 for $<arglist>.ast.list { $qast[0].push( $_ ) }
             }
             elsif $<nibbler> {
-                $name eq 'after' ??
-                    $qast[0].push(self.qbuildsub(self.flip_ast($<nibbler>.ast), :anon(1), :addself(1))) !!
+                if $name eq 'after' {
+                    if self.can_flip_ast($<nibbler>.ast) {
+                        $qast[0].push(self.qbuildsub(self.flip_ast($<nibbler>.ast), :anon(1), :addself(1)));
+                    }
+                    else {
+                        $qast[0][0].value('after_scan');
+                        $qast[0].push(self.qbuildsub($<nibbler>.ast, :anon(1), :addself(1)));
+                    }
+                }
+                else {
                     $qast[0].push(self.qbuildsub($<nibbler>.ast, :anon(1), :addself(1)));
+                }
             }
         }
         make $qast;

--- a/src/QRegex/P6Regex/Actions.nqp
+++ b/src/QRegex/P6Regex/Actions.nqp
@@ -608,8 +608,12 @@ class QRegex::P6Regex::Actions is HLL::Actions {
                         $qast[0].push(self.qbuildsub($<nibbler>.ast, :node($/), :anon(1), :addself(1)));
                         $qast[0].push(QAST::IVal.new( :value($litlen) ));  # optional offset to before
                     }
-                    else {
+                    elsif self.can_flip_ast($<nibbler>.ast) {
                         $qast[0].push(self.qbuildsub(self.flip_ast($<nibbler>.ast), :node($/), :anon(1), :addself(1)));
+                    }
+                    else {
+                        $qast[0][0].value('after_scan');
+                        $qast[0].push(self.qbuildsub($<nibbler>.ast, :node($/), :anon(1), :addself(1)));
                     }
                 }
                 else {
@@ -1006,6 +1010,35 @@ class QRegex::P6Regex::Actions is HLL::Actions {
             return $litlen;
         }
         return -1;
+    }
+
+    # Whether flip_ast can turn this syntax tree into one that, matched
+    # against the flipped target, is equivalent to matching the original
+    # right-to-left.  Subrule calls and embedded code have compiled bodies
+    # that match left-to-right no matter what surrounds them, and
+    # zero-width checks other than anchors inspect the character at the
+    # current position, which is on the other side once the target is
+    # flipped.  Lookbehinds containing any of those must scan instead.
+    method can_flip_ast($qast) {
+        return 1 unless nqp::istype($qast, QAST::Regex);
+        return 0 if $qast.subtype eq 'zerowidth';
+        my $rxtype := $qast.rxtype;
+        if $rxtype eq 'literal' || $rxtype eq 'cclass' || $rxtype eq 'enumcharlist'
+          || $rxtype eq 'charrange' || $rxtype eq 'uniprop'
+          || $rxtype eq 'anchor' || $rxtype eq 'dba' {
+            1
+        }
+        elsif $rxtype eq 'concat' || $rxtype eq 'alt' || $rxtype eq 'altseq'
+          || $rxtype eq 'conj' || $rxtype eq 'conjseq'
+          || $rxtype eq 'quant' || $rxtype eq 'dynquant' {
+            for @($qast) {
+                return 0 unless self.can_flip_ast($_);
+            }
+            1
+        }
+        else {
+            0
+        }
     }
 
     method flip_ast($qast) {

--- a/t/nqp/119-lookbehind.t
+++ b/t/nqp/119-lookbehind.t
@@ -1,0 +1,53 @@
+plan(12);
+
+# Lookbehind is compiled by reversing its pattern and matching against the
+# reversed target.  Pattern nodes whose compiled bodies always match
+# left-to-right (subrule calls, and zero-width checks other than anchors)
+# cannot be reversed that way, so lookbehinds containing them scan for a
+# match that ends at the current position instead.
+
+grammar Subrule {
+    token ab  { ab }
+    token TOP { .. <?after <.ab>> .* }
+}
+ok( ?Subrule.parse('abba'), 'lookbehind calling a subrule matches the text behind');
+ok( !Subrule.parse('baab'), 'lookbehind calling a subrule fails on other text behind');
+
+grammar SubruleNeg {
+    token ab  { ab }
+    token TOP { .. <!after <.ab>> .* }
+}
+ok( ?SubruleNeg.parse('baab'), 'negated lookbehind with a subrule matches when the subrule cannot end here');
+ok( !SubruleNeg.parse('abba'), 'negated lookbehind with a subrule fails when the subrule ends here');
+
+grammar SubruleAnchor {
+    token ab  { ab }
+    token TOP { .* <?after ^ <.ab>> .* }
+}
+ok( ?SubruleAnchor.parse('ab'),  'anchor inside a scanning lookbehind holds at the start of the target');
+ok( !SubruleAnchor.parse('xab'), 'anchor inside a scanning lookbehind fails away from the start');
+
+grammar PeekAhead {
+    token TOP { ab <?after a <?[b]> b> }
+}
+ok( ?PeekAhead.parse('ab'), 'zero-width peek inside a lookbehind checks the character ahead');
+
+grammar PeekAheadWrong {
+    token TOP { ab <?after a <?[a]> b> }
+}
+ok( !PeekAheadWrong.parse('ab'), 'zero-width peek inside a lookbehind does not check the character behind');
+
+grammar Capture {
+    token ab  { ab }
+    token TOP { .. <after <.ab>> .* }
+}
+my $m := Capture.parse('abba');
+ok( ?$m, 'capturing lookbehind with a subrule matches');
+ok( $m<after>.from == 2 && $m<after>.pos == 2, 'capturing lookbehind produces a zero-width match at the current position');
+
+grammar CaptureFlip {
+    token TOP { ... <after a+ b> }
+}
+$m := CaptureFlip.parse('aab');
+ok( ?$m, 'capturing lookbehind on the flipped-match path matches');
+ok( $m<after>.from == 3 && $m<after>.pos == 3, 'flipped-match capturing lookbehind also produces a zero-width match at the current position');


### PR DESCRIPTION
The <?after ...> assertion compiles by reversing the pattern syntax tree and matching it against a reversed copy of the target string. flip_ast only knows how to reverse some nodes. Subrule calls (named rules, interpolated patterns, backreferences), embedded code, and zero-width checks other than anchors were left matching left-to-right against the reversed target, giving wrong results:

    my regex ab { ab }
    say .pos given 'ab ba' ~~ / <?after <ab> > /;  # 5, should be 2

Previously the reversal was unconditional. Now the actions only reverse when can_flip_ast confirms every node in the pattern is one flip_ast handles. Otherwise the call is emitted against the new after_scan method, which matches the unmodified pattern forward from each position at or before the current one and succeeds if any match ends exactly at the current position. A match that ends elsewhere is backtracked into so a pattern like 'a || ab' can still find the ending that lines up.

The after method now also passes or fails on a fresh cursor rather than the one the regex ran on. That cursor held the reversed target and a $!from in reversed-string coordinates, which made the capturing <after ...> form produce a negative-width match object.

P5Regex lookbehinds get the same treatment. Its flip_ast only reverses literals and concat order, so its can_flip_ast additionally sends anchors down the scanning path.

Helps resolve rakudo/rakudo#6087